### PR TITLE
Prioritize using bssids for identification

### DIFF
--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -23,7 +23,7 @@
 
 namespace yarilo {
 
-AccessPoint::AccessPoint(const Tins::HWAddress<6> &bssid, const SSID &ssid,
+AccessPoint::AccessPoint(const MACAddress &bssid, const SSID &ssid,
                          int wifi_channel)
     : decrypter(bssid, ssid) {
   logger = spdlog::get(ssid);
@@ -47,7 +47,7 @@ bool AccessPoint::handle_pkt(Tins::Packet *pkt) {
 
 SSID AccessPoint::get_ssid() { return ssid; }
 
-Tins::HWAddress<6> AccessPoint::get_bssid() { return bssid; }
+MACAddress AccessPoint::get_bssid() { return bssid; }
 
 int AccessPoint::get_wifi_channel() { return wifi_channel; }
 
@@ -87,8 +87,7 @@ bool AccessPoint::add_password(const std::string &psk) {
   return true;
 };
 
-bool AccessPoint::send_deauth(Tins::NetworkInterface *iface,
-                              Tins::HWAddress<6> addr) {
+bool AccessPoint::send_deauth(Tins::NetworkInterface *iface, MACAddress addr) {
   if (!radio_length)
     return false;
 
@@ -216,8 +215,9 @@ bool AccessPoint::handle_mgmt(Tins::Packet *pkt) {
 
 std::unique_ptr<Tins::EthernetII>
 AccessPoint::make_eth_packet(Tins::Dot11Data *data) {
-  Tins::HWAddress<6> dst;
-  Tins::HWAddress<6> src;
+  // TODO: Change detection
+  MACAddress dst;
+  MACAddress src;
 
   if (data->from_ds() && !data->to_ds()) {
     dst = data->addr1();

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -26,8 +26,7 @@ public:
    * @param[in] ssid name of the network
    * @param[in] wifi_channel channel of the network (1-14)
    */
-  AccessPoint(const Tins::HWAddress<6> &bssid, const SSID &ssid,
-              int wifi_channel);
+  AccessPoint(const MACAddress &bssid, const SSID &ssid, int wifi_channel);
 
   /**
    * A method for handling incoming packets inside this network, if you
@@ -57,7 +56,7 @@ public:
    * Get this networks BSSID (MAC of the station)
    * @return the BSSID of the network
    */
-  Tins::HWAddress<6> get_bssid();
+  MACAddress get_bssid();
 
   /**
    * Get this networks wifi channel
@@ -79,7 +78,7 @@ public:
    * @return True if the packet was sent, False if the device doesn't exist, or
    * other error
    */
-  bool send_deauth(Tins::NetworkInterface *iface, Tins::HWAddress<6> addr);
+  bool send_deauth(Tins::NetworkInterface *iface, MACAddress addr);
 
   /**
    * Get if the network already has a working psk (one that generated a valid
@@ -128,7 +127,7 @@ public:
 private:
   std::shared_ptr<spdlog::logger> logger;
   SSID ssid;
-  Tins::HWAddress<6> bssid;
+  MACAddress bssid;
   int wifi_channel = 0;
   std::vector<Tins::Packet *> captured_packets;
   WPA2Decrypter decrypter;

--- a/backend/src/decrypter.h
+++ b/backend/src/decrypter.h
@@ -224,7 +224,7 @@ private:
   std::map<MACAddress, Tins::Packet *> group_rekey_first_messages;
   std::map<MACAddress, std::vector<Tins::Packet *>> client_handshakes;
   const SSID ssid;
-  const Tins::HWAddress<6> bssid;
+  const MACAddress bssid;
   std::string psk = "";
   bool working_psk = false;
   std::map<MACAddress, std::vector<client_window>> client_windows;

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -44,10 +44,10 @@ void Service::add_save_path(std::filesystem::path path) {
 grpc::Status Service::GetAllAccessPoints(grpc::ServerContext *context,
                                          const proto::Empty *request,
                                          proto::NetworkList *reply) {
-  std::set<SSID> names = sniffinson->all_networks();
+  std::set<Sniffer::network_name> names = sniffinson->all_networks();
   for (const auto &name : names) {
     auto new_name = reply->add_names();
-    *new_name = std::string(name);
+    *new_name = std::string(name.second);
   }
 
   return grpc::Status::OK;
@@ -250,7 +250,7 @@ grpc::Status Service::IgnoreNetwork(grpc::ServerContext *context,
 grpc::Status Service::GetIgnoredNetworks(grpc::ServerContext *context,
                                          const proto::Empty *request,
                                          proto::NetworkList *reply) {
-  for (const auto &ssid : sniffinson->ignored_networks())
+  for (const auto &ssid : sniffinson->ignored_network_names())
     *reply->add_names() = ssid;
   return grpc::Status::OK;
 };


### PR DESCRIPTION
# Changed

- Most `Sniffer` methods now are overloaded to accept both network names (SSID) and network addresses (BSSID)