### PR TITLE
Security detection support

### DIFF
--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -10,13 +10,15 @@ using NetworkSecurity = yarilo::AccessPoint::NetworkSecurity;
 
 namespace yarilo {
 
-AccessPoint::AccessPoint(const MACAddress &bssid, const SSID &ssid)
+AccessPoint::AccessPoint(const MACAddress &bssid, const SSID &ssid,
+                         int wifi_channel)
     : ssid(ssid), bssid(bssid), decrypter(bssid, ssid) {
   logger = spdlog::get(ssid);
   if (!logger)
     logger = spdlog::stdout_color_mt(ssid);
   logger->debug("Station found on channel {} with addr {}", wifi_channel,
                 bssid.to_string());
+  this->wifi_channel = wifi_channel;
 };
 
 bool AccessPoint::handle_pkt(Tins::Packet *pkt) {

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -33,7 +33,8 @@ public:
    */
   struct client_security {
     NetworkSecurity security;
-    bool is_ccmp;
+    bool is_ccmp = false;
+    bool pmf_enforced = false;
     std::optional<Tins::RSNInformation::CypherSuites> pairwise_cipher;
   };
 
@@ -66,19 +67,19 @@ public:
    * Get this networks SSID
    * @return the ssid of the network
    */
-  SSID get_ssid();
+  SSID get_ssid() const;
 
   /**
    * Get this networks BSSID (MAC of the station)
    * @return the BSSID of the network
    */
-  MACAddress get_bssid();
+  MACAddress get_bssid() const;
 
   /**
    * Get this networks wifi channel
    * @return the wifi channel of the network
    */
-  int get_wifi_channel();
+  int get_wifi_channel() const;
 
   /**
    * Get the converted data channel for this network
@@ -94,32 +95,33 @@ public:
    * @return True if the packet was sent, False if the device doesn't exist, or
    * other error
    */
-  bool send_deauth(const Tins::NetworkInterface &iface, const MACAddress &addr);
+  bool send_deauth(const Tins::NetworkInterface &iface,
+                   const MACAddress &addr) const;
 
   /**
    * Get if the network already has a working psk (one that generated a valid
    * keypair)
    * @return True if one psk already works
    */
-  bool has_working_password();
+  bool has_working_password() const;
 
   /**
    * Get supported security modes (e.g. WPA2-PSK)
    * @return List of supported security modes
    */
-  std::vector<NetworkSecurity> supported_security();
+  std::vector<NetworkSecurity> supported_security() const;
 
   /**
    * Get if the network has unicast decryption support
    * @return True if the network supports being decrypted
    */
-  bool unicast_decryption_support();
+  bool unicast_decryption_support() const;
 
   /**
    * Get if the network has group decryption support
    * @return True if the network supports being decrypted
    */
-  bool group_decryption_support();
+  bool group_decryption_support() const;
 
   /**
    * Get if this client has unicast decryption support
@@ -131,7 +133,13 @@ public:
    * Get if the network protects its management frames
    * @return True if 802.11w is in place
    */
-  bool protected_management_support();
+  bool protected_management_support() const;
+
+  /*
+   * Get if the network protects its management frames for a specific client
+   * @return True if 802.11w is enforced for a client
+   */
+  bool protected_management_enforced(const MACAddress &client);
 
   /**
    * Get the decrypter
@@ -143,13 +151,13 @@ public:
    * Unencrypted packets count
    * @return count of raw data packets in the queue
    */
-  int raw_packet_count();
+  int raw_packet_count() const;
 
   /**
    * Decrypted packets data count
    * @return count of decrypted data packets in the queue
    */
-  int decrypted_packet_count();
+  int decrypted_packet_count() const;
 
   /**
    * Save decrypted traffic

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -16,9 +16,8 @@ public:
    * A constructor which creates the access point based on AP data
    * @param[in] bssid hwaddr of the network
    * @param[in] ssid name of the network
-   * @param[in] wifi_channel channel of the network (1-14)
    */
-  AccessPoint(const MACAddress &bssid, const SSID &ssid, int wifi_channel);
+  AccessPoint(const MACAddress &bssid, const SSID &ssid);
 
   /**
    * A method for handling incoming packets inside this network, if you
@@ -80,22 +79,22 @@ public:
   bool has_working_password();
 
   /**
-   * Get the decrypter
-   * @return The WPA2 decrypter
+   * Get if the network has decryption support
+   * @return True if the network supports being decrypted
    */
-  WPA2Decrypter &get_decrypter();
+  bool decryption_support();
 
   /*
    * Get if the network protects its management frames
    * @return True if 802.11w is in place
    */
-  bool management_protected();
+  bool protected_management_support();
 
   /**
-   * Update the desired channel of the access point
-   * @param[in] channel wifi channel to use
+   * Get the decrypter
+   * @return The WPA2 decrypter
    */
-  void update_wifi_channel(int i);
+  WPA2Decrypter &get_decrypter();
 
   /**
    * Unencrypted packets count
@@ -131,20 +130,20 @@ private:
   uint8_t radio_channel_type = 0;
   uint8_t radio_antenna = 0;
 
-  // Determine if we can spoof deauth packets, 802.11w
-  bool protected_mgmt_frames = false;
+  bool pmf_supported = false; // Protected management frames - 802.11w
+  bool decryption_supported = false;
 
   /**
-   * A method for handling "802.11 Data" packets inside this network
+   * Handling "802.11 Data" packets inside this network
    * @param[in] pkt A pointer to a saved packet
    */
   bool handle_data(Tins::Packet *pkt);
 
   /**
-   * A method for handling "802.11 Management" packets inside this network
+   * Handling "802.11 Data" packets inside this network
    * @param[in] pkt A pointer to a saved packet
    */
-  bool handle_mgmt(Tins::Packet *pkt);
+  bool handle_management(Tins::Packet *pkt);
 
   /**
    * Create an ethernet packet based on the decrypted 802.11 packet

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -4,8 +4,23 @@
 #include "channel.h"
 #include "decrypter.h"
 #include <filesystem>
+#include <vector>
 
 namespace yarilo {
+
+/**
+ * @brief Network security protocol used. A network can support multiple ways to
+ * connect and secure data
+ */
+enum class NetworkSecurity {
+  OPEN,
+  WEP,
+  WPA,
+  WPA2_Personal,
+  WPA2_Enterprise,
+  WPA3_Personal,
+  WPA3_Enterprise,
+};
 
 /**
  * @brief Access Point in a basic service set (BSS) network
@@ -79,6 +94,12 @@ public:
   bool has_working_password();
 
   /**
+   * Get supported security modes (e.g. WPA2-PSK)
+   * @return List of supported security modes
+   */
+  std::vector<NetworkSecurity> supported_security();
+
+  /**
    * Get if the network has decryption support
    * @return True if the network supports being decrypted
    */
@@ -130,8 +151,9 @@ private:
   uint8_t radio_channel_type = 0;
   uint8_t radio_antenna = 0;
 
+  bool security_detected = false;
+  std::vector<NetworkSecurity> security_modes;
   bool pmf_supported = false; // Protected management frames - 802.11w
-  bool decryption_supported = false;
 
   /**
    * Handling "802.11 Data" packets inside this network
@@ -144,6 +166,13 @@ private:
    * @param[in] pkt A pointer to a saved packet
    */
   bool handle_management(Tins::Packet *pkt);
+
+  /**
+   * Detect the security described in this management packet
+   * @param[in] mgtm A reference to a management packet
+   */
+  std::vector<NetworkSecurity>
+  detect_security_modes(const Tins::Dot11ManagementFrame &mgmt) const;
 
   /**
    * Create an ethernet packet based on the decrypted 802.11 packet

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -42,8 +42,9 @@ public:
    * A constructor which creates the access point based on AP data
    * @param[in] bssid hwaddr of the network
    * @param[in] ssid name of the network
+   * @param[in] wifi_channel wifi channel for this network
    */
-  AccessPoint(const MACAddress &bssid, const SSID &ssid);
+  AccessPoint(const MACAddress &bssid, const SSID &ssid, int wifi_channel);
 
   /**
    * A method for handling incoming packets inside this network, if you
@@ -80,6 +81,14 @@ public:
    * @return the wifi channel of the network
    */
   int get_wifi_channel() const;
+
+  /**
+   * Set this networks wifi channel
+   * @param[in] the new wifi channel of the network
+   */
+  void set_wifi_channel(int wifi_channel) {
+    this->wifi_channel = wifi_channel;
+  };
 
   /**
    * Get the converted data channel for this network

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -154,6 +154,7 @@ private:
   bool security_detected = false;
   std::vector<NetworkSecurity> security_modes;
   bool pmf_supported = false; // Protected management frames - 802.11w
+  bool uses_ccmp = false;
 
   /**
    * Handling "802.11 Data" packets inside this network
@@ -173,6 +174,12 @@ private:
    */
   std::vector<NetworkSecurity>
   detect_security_modes(const Tins::Dot11ManagementFrame &mgmt) const;
+
+  /**
+   * Detect if the used cipher is CCMP
+   * @param[in] mgtm A reference to a management packet
+   */
+  bool is_ccmp(const Tins::Dot11ManagementFrame &mgmt) const;
 
   /**
    * Create an ethernet packet based on the decrypted 802.11 packet

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -34,7 +34,7 @@ public:
   struct client_security {
     NetworkSecurity security;
     bool is_ccmp = false;
-    bool pmf_enforced = false;
+    bool pmf = false;
     std::optional<Tins::RSNInformation::CypherSuites> pairwise_cipher;
   };
 
@@ -118,37 +118,37 @@ public:
    * Get supported security modes (e.g. WPA2-PSK)
    * @return List of supported security modes
    */
-  std::vector<NetworkSecurity> supported_security() const;
+  std::vector<NetworkSecurity> security_supported() const;
 
   /**
    * Get if the network has unicast decryption support
    * @return True if the network supports being decrypted
    */
-  bool unicast_decryption_support() const;
+  bool unicast_decryption_supported() const;
 
   /**
    * Get if the network has group decryption support
    * @return True if the network supports being decrypted
    */
-  bool group_decryption_support() const;
+  bool group_decryption_supported() const;
 
   /**
    * Get if this client has unicast decryption support
    * @return True if the client supports being decrypted
    */
-  bool client_decryption_support(const MACAddress &client);
+  bool client_decryption_supported(const MACAddress &client);
 
   /*
-   * Get if the network protects its management frames
+   * Get if the network can protect its management frames
    * @return True if 802.11w is in place
    */
-  bool protected_management_support() const;
+  bool protected_management_supported() const;
 
   /*
    * Get if the network protects its management frames for a specific client
    * @return True if 802.11w is enforced for a client
    */
-  bool protected_management_enforced(const MACAddress &client);
+  bool protected_management(const MACAddress &client);
 
   /**
    * Get the decrypter

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -213,7 +213,7 @@ grpc::Status Service::DeauthNetwork(grpc::ServerContext *context,
     return grpc::Status(grpc::StatusCode::NOT_FOUND,
                         "No network with this ssid");
 
-  bool pmf = ap.value()->protected_management_support();
+  bool pmf = ap.value()->protected_management_supported();
   if (pmf)
     return grpc::Status(grpc::StatusCode::UNAVAILABLE,
                         "Target network uses protected management frames");

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -213,7 +213,7 @@ grpc::Status Service::DeauthNetwork(grpc::ServerContext *context,
     return grpc::Status(grpc::StatusCode::NOT_FOUND,
                         "No network with this ssid");
 
-  bool pmf = ap.value()->management_protected();
+  bool pmf = ap.value()->protected_management_support();
   if (pmf)
     return grpc::Status(grpc::StatusCode::UNAVAILABLE,
                         "Target network uses protected management frames");

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -1,4 +1,5 @@
 #include "sniffer.h"
+#include "decrypter.h"
 #include <absl/strings/str_format.h>
 #include <net/if.h>
 
@@ -249,69 +250,10 @@ bool Sniffer::handle_pkt(Tins::Packet &pkt) {
   }
 
   Tins::PDU *pdu = pkt.pdu();
-  if (pdu->find_pdu<Tins::Dot11Beacon>())
-    return handle_beacon(pkt);
-  if (pdu->find_pdu<Tins::Dot11ProbeResponse>())
-    return handle_probe_response(pkt);
   if (pdu->find_pdu<Tins::Dot11Data>())
     return handle_data(pkt);
   if (pdu->find_pdu<Tins::Dot11ManagementFrame>())
     return handle_management(pkt);
-  return true;
-}
-
-bool Sniffer::handle_beacon(Tins::Packet &pkt) {
-  auto beacon = pkt.pdu()->rfind_pdu<Tins::Dot11Beacon>();
-  MACAddress bssid = beacon.addr3();
-  if (ignored_net_addrs.count(bssid))
-    return true;
-
-  SSID ssid = beacon.ssid();
-  if (ignored_net_names.count(ssid)) {
-    ignored_net_addrs.insert(bssid);
-    return true;
-  }
-
-  // NOTE: We are not taking the channel from the frequency here! It would be
-  // the frequency of the beacon/proberesp packet and NOT necessarily the
-  // network itself, there is a chance we get a "DS Parameter: active channel"
-  // tagged param in the management packet body
-  bool has_channel = beacon.search_option(Tins::Dot11::OptionTypes::DS_SET);
-  int current_wifi_channel = has_channel ? beacon.ds_parameter_set() : 1;
-
-  // TODO: Does wlan.fixed.capabilities.spec_man matter here?
-  if (!aps.count(bssid)) {
-    aps[bssid] = std::make_shared<AccessPoint>(bssid, beacon.ssid(),
-                                               current_wifi_channel);
-  } else if (has_channel) {
-    aps[bssid]->update_wifi_channel(current_wifi_channel);
-  }
-
-  return true;
-}
-
-bool Sniffer::handle_probe_response(Tins::Packet &pkt) {
-  auto probe_resp = pkt.pdu()->rfind_pdu<Tins::Dot11ProbeResponse>();
-  MACAddress bssid = probe_resp.addr3();
-  if (ignored_net_addrs.count(bssid))
-    return true;
-
-  SSID ssid = probe_resp.ssid();
-  if (ignored_net_names.count(ssid)) {
-    ignored_net_addrs.insert(bssid);
-    return true;
-  }
-
-  bool has_channel = probe_resp.search_option(Tins::Dot11::OptionTypes::DS_SET);
-  int current_wifi_channel = has_channel ? probe_resp.ds_parameter_set() : 1;
-
-  // TODO: Does wlan.fixed.capabilities.spec_man matter here?
-  if (!aps.count(bssid)) {
-    aps[bssid] =
-        std::make_shared<AccessPoint>(bssid, ssid, current_wifi_channel);
-  } else if (has_channel) {
-    aps[bssid]->update_wifi_channel(current_wifi_channel);
-  }
   return true;
 }
 
@@ -327,18 +269,23 @@ bool Sniffer::handle_data(Tins::Packet &pkt) {
 
 bool Sniffer::handle_management(Tins::Packet &pkt) {
   auto mgmt = pkt.pdu()->rfind_pdu<Tins::Dot11ManagementFrame>();
-  MACAddress bssid;
-
-  if ((mgmt.from_ds() && !mgmt.to_ds()) || (!mgmt.from_ds() && mgmt.to_ds())) {
-    bssid = mgmt.addr3();
-  } else
+  if (!pkt.pdu()->find_pdu<Tins::Dot11ProbeResponse>() &&
+      !pkt.pdu()->find_pdu<Tins::Dot11Beacon>())
     return true;
 
-  for (const auto &[addr, ap] : aps)
-    if (addr == bssid)
-      return ap->handle_pkt(save_pkt(pkt));
+  MACAddress bssid = mgmt.addr3();
+  if (ignored_net_addrs.count(bssid))
+    return true;
 
-  return true;
+  SSID ssid = mgmt.ssid();
+  if (ignored_net_names.count(ssid)) {
+    ignored_net_addrs.insert(bssid);
+    return true;
+  }
+
+  if (!aps.count(bssid))
+    aps[bssid] = std::make_shared<AccessPoint>(bssid, mgmt.ssid());
+  return aps[bssid]->handle_pkt(&pkt);
 }
 
 Tins::Packet *Sniffer::save_pkt(Tins::Packet &pkt) {

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -189,23 +189,6 @@ private:
   bool handle_pkt(Tins::Packet &pkt);
 
   /**
-   * Handle a 802.11 beacon packet. A beacon packet is sent by an AP to
-   * broadcast its capabilities and allow users to detect the network.
-   * @param[in] pkt Packet to be processed
-   * @return True if sniffing should be continued
-   */
-  bool handle_beacon(Tins::Packet &pkt);
-
-  /**
-   * Handle a 802.11 probe response packet. It is a response to a probe request
-   * packet broadcast by a client to discover networks. It has roughly the same
-   * info as a beacon packet.
-   * @param[in] pkt Packet to be processed
-   * @return True if sniffing should be continued
-   */
-  bool handle_probe_response(Tins::Packet &pkt);
-
-  /**
    * Handle a 802.11 data packet.
    * @param[in] pkt Packet to be processed
    * @return True if sniffing should be continued


### PR DESCRIPTION
# Added

- `AccessPoint` now has methods to determine which security standards are supported, or if the network can be decrypted at all. Our decryption supports only  `WPA2-Personal` with `CCMP` and `TKIP` for unicast traffic and only `CCMP` for group traffic - solves #36 
- Access points now also detect which security standard was used while connecting, for example in situations where the AP uses both `WPA2-PSK` and `WPA3-SAE` we are able to tell which client uses which feature.
- Detecting protected management frames for a client by the used standard (WPA3 enforces PMF) or noticing frames directed at a certain client