### PR TITLE
Multiple sniffers

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -11,6 +11,12 @@
 #include <optional>
 #include <tins/utils/routing_utils.h>
 
+static std::unique_ptr<grpc::Server> server;
+static std::unique_ptr<yarilo::Service> service;
+static std::atomic<bool> shutdown_required = false;
+static std::mutex shutdown_mtx;
+static std::condition_variable shutdown_cv;
+
 ABSL_FLAG(std::optional<std::string>, sniff_file, std::nullopt,
           "Filename to sniff on");
 ABSL_FLAG(std::optional<std::string>, iface, std::nullopt,
@@ -18,7 +24,10 @@ ABSL_FLAG(std::optional<std::string>, iface, std::nullopt,
           "Mutually exclusive with the filename option.");
 ABSL_FLAG(uint32_t, port, 9090, "Port to serve the grpc server on");
 ABSL_FLAG(std::string, save_path, "/opt/yarlilo/saves",
-          "Directory that saves will reside in");
+          "Directory that yarilo will use to save decrypted traffic");
+ABSL_FLAG(std::string, sniff_files_path, "/opt/yarlilo/sniff_files",
+          "Directory which will be searched for sniff files (raw montior mode "
+          "recordings)");
 ABSL_FLAG(std::string, log_level, "info", "Log level (debug, info, trace)");
 
 std::optional<std::shared_ptr<spdlog::logger>> init_logger() {
@@ -37,64 +46,6 @@ std::optional<std::shared_ptr<spdlog::logger>> init_logger() {
   }
   return log;
 }
-
-std::optional<std::unique_ptr<yarilo::Service>>
-init_service(std::shared_ptr<spdlog::logger> log) {
-  std::optional<std::string> iface_candidate = absl::GetFlag(FLAGS_iface);
-  std::optional<std::string> filename = absl::GetFlag(FLAGS_sniff_file);
-
-  if (iface_candidate.has_value() && filename.has_value()) {
-    log->error("Incorrect usage, both filename and network card interface was "
-               "specified");
-    return std::nullopt;
-  }
-
-  if (!iface_candidate.has_value() && !filename.has_value()) {
-    log->info("Sniffing pure air (no sniffers active)");
-    return std::make_unique<yarilo::Service>();
-  }
-
-  std::unique_ptr<yarilo::Service> service;
-  if (filename.has_value()) {
-    log->info("Sniffing using filename: {}", filename.value());
-    try {
-      auto sniffer = std::make_unique<Tins::FileSniffer>(filename.value());
-      service = std::make_unique<yarilo::Service>(std::move(sniffer));
-    } catch (const Tins::pcap_error &e) {
-      log->error("Error while initializing the sniffer: {}", e.what());
-      return std::nullopt;
-    }
-
-    return service;
-  }
-
-  std::optional<std::string> iface =
-      yarilo::Sniffer::detect_interface(log, iface_candidate.value());
-  if (!iface.has_value()) {
-    log->critical("Didn't find suitable interface, bailing out");
-    return std::nullopt;
-  }
-
-  log->info("Sniffing using interface: {}", iface.value());
-
-  std::set<std::string> interfaces = Tins::Utils::network_interfaces();
-  if (!interfaces.count(iface.value())) {
-    log->critical("There is no available interface by that name: {}",
-                  iface.value());
-    return std::nullopt;
-  }
-
-  try {
-    auto sniffer = std::make_unique<Tins::Sniffer>(iface.value());
-    service = std::make_unique<yarilo::Service>(
-        std::move(sniffer), Tins::NetworkInterface(iface.value()));
-  } catch (const Tins::pcap_error &e) {
-    log->error("Error while initializing the sniffer: {}", e.what());
-    return std::nullopt;
-  }
-
-  return service;
-};
 
 std::optional<std::filesystem::path>
 init_saves(std::shared_ptr<spdlog::logger> log) {
@@ -116,11 +67,46 @@ init_saves(std::shared_ptr<spdlog::logger> log) {
   return saves;
 }
 
-static std::unique_ptr<grpc::Server> server;
-static std::unique_ptr<yarilo::Service> service;
-static std::atomic<bool> shutdown_required = false;
-static std::mutex shutdown_mtx;
-static std::condition_variable shutdown_cv;
+std::optional<std::filesystem::path>
+init_sniff_files(std::shared_ptr<spdlog::logger> log) {
+  std::filesystem::path sniff_files = absl::GetFlag(FLAGS_sniff_files_path);
+  if (!std::filesystem::exists(sniff_files)) {
+    log->info("Sniff files path not found, creating");
+    try {
+      std::filesystem::create_directories(sniff_files);
+    } catch (const std::runtime_error &e) {
+      log->critical("Cannot create sniff files directory at {}, {}",
+                    sniff_files.string(), e.what());
+      return std::nullopt;
+    }
+  } else if (!std::filesystem::is_directory(sniff_files)) {
+    log->critical("Sniff files path {} is not a directory!",
+                  sniff_files.string());
+    return std::nullopt;
+  }
+
+  return sniff_files;
+}
+
+bool init_first_sniffer(std::shared_ptr<spdlog::logger> log) {
+  std::optional<std::string> net_iface_name = absl::GetFlag(FLAGS_iface);
+  std::optional<std::string> filename = absl::GetFlag(FLAGS_sniff_file);
+
+  if (net_iface_name.has_value() && filename.has_value()) {
+    log->error("Incorrect usage, both filename and network card interface was "
+               "specified");
+    return false;
+  }
+
+  if (!net_iface_name.has_value() && !filename.has_value()) {
+    log->info("No sniffers initialized");
+    return true;
+  }
+
+  if (filename.has_value())
+    return service->add_file_sniffer(filename.value());
+  return service->add_iface_sniffer(net_iface_name.value());
+}
 
 void handle_signal(int sig) {
   const std::lock_guard lock(shutdown_mtx);
@@ -146,45 +132,45 @@ int main(int argc, char *argv[]) {
                    "--log_level=trace"));
   absl::ParseCommandLine(argc, argv);
 
-  auto log_opt = init_logger();
+  std::optional<std::shared_ptr<spdlog::logger>> log_opt = init_logger();
   if (!log_opt.has_value())
     return 1;
-  auto log = log_opt.value();
+  std::shared_ptr<spdlog::logger> logger = log_opt.value();
 
-  log->info("Starting Yarilo");
+  logger->info("Starting Yarilo");
 
 #ifdef MAYHEM
-  log->info("Mayhem enabled, use the appropriate endpoints to toggle it");
+  logger->info("Mayhem enabled, use the appropriate endpoints to toggle it");
 #endif
 
-  auto saves_opt = init_saves(log);
-  if (!saves_opt.has_value())
+  std::optional<std::filesystem::path> saves_path = init_saves(logger);
+  if (!saves_path.has_value())
     return 1;
-  auto saves = saves_opt.value();
 
-  auto service_opt = init_service(log);
-  if (!service_opt.has_value())
+  std::optional<std::filesystem::path> sniff_files_path =
+      init_sniff_files(logger);
+  if (!sniff_files_path.has_value())
     return 1;
-  service = std::move(service_opt.value());
-  log->info("Using save path: {}", saves.string());
 
-  service->add_save_path(saves);
+  service = std::make_unique<yarilo::Service>(saves_path.value(),
+                                              sniff_files_path.value());
+  if (!init_first_sniffer(logger))
+    return 1;
+
   std::string server_address =
       absl::StrFormat("0.0.0.0:%d", absl::GetFlag(FLAGS_port));
-
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(service.get());
-  log->info("Serving on port {}", absl::GetFlag(FLAGS_port));
+  logger->info("Serving on port {}", absl::GetFlag(FLAGS_port));
 
   std::signal(SIGINT, handle_signal);
   std::signal(SIGQUIT, handle_signal);
   std::signal(SIGTERM, handle_signal);
   std::thread t(shutdown_check);
   server = builder.BuildAndStart();
-  service->start();
   t.join();
   return 0;
 };

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -104,7 +104,7 @@ grpc::Status Service::SnifferCreate(grpc::ServerContext *context,
 grpc::Status Service::SnifferDestroy(grpc::ServerContext *context,
                                      const proto::SnifferID *request,
                                      proto::Empty *reply) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   sniffers[request->id()]->shutdown();
   sniffers.erase(sniffers.begin() + request->id());
@@ -164,7 +164,7 @@ Service::SniffInterfaceList(grpc::ServerContext *context,
 grpc::Status Service::GetAllAccessPoints(grpc::ServerContext *context,
                                          const proto::SnifferID *request,
                                          proto::NetworkList *reply) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->id()].get();
 
@@ -180,7 +180,7 @@ grpc::Status Service::GetAllAccessPoints(grpc::ServerContext *context,
 grpc::Status Service::GetAccessPoint(grpc::ServerContext *context,
                                      const proto::NetworkName *request,
                                      proto::NetworkInfo *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -224,7 +224,7 @@ grpc::Status Service::GetAccessPoint(grpc::ServerContext *context,
 grpc::Status Service::FocusNetwork(grpc::ServerContext *context,
                                    const proto::NetworkName *request,
                                    proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -242,7 +242,7 @@ grpc::Status Service::FocusNetwork(grpc::ServerContext *context,
 grpc::Status Service::GetFocusState(grpc::ServerContext *context,
                                     const proto::SnifferID *request,
                                     proto::FocusState *reply) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->id()].get();
 
@@ -262,7 +262,7 @@ grpc::Status Service::GetFocusState(grpc::ServerContext *context,
 grpc::Status Service::StopFocus(grpc::ServerContext *context,
                                 const proto::SnifferID *request,
                                 proto::Empty *reply) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->id()].get();
 
@@ -273,7 +273,7 @@ grpc::Status Service::StopFocus(grpc::ServerContext *context,
 grpc::Status Service::ProvidePassword(ServerContext *context,
                                       const proto::DecryptRequest *request,
                                       proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -297,7 +297,7 @@ grpc::Status
 Service::GetDecryptedPackets(grpc::ServerContext *context,
                              const proto::NetworkName *request,
                              grpc::ServerWriter<proto::Packet> *writer) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -366,7 +366,7 @@ Service::GetDecryptedPackets(grpc::ServerContext *context,
 grpc::Status Service::DeauthNetwork(grpc::ServerContext *context,
                                     const proto::DeauthRequest *request,
                                     proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -398,7 +398,7 @@ grpc::Status Service::DeauthNetwork(grpc::ServerContext *context,
 grpc::Status Service::IgnoreNetwork(grpc::ServerContext *context,
                                     const proto::NetworkName *request,
                                     proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -413,7 +413,7 @@ grpc::Status Service::IgnoreNetwork(grpc::ServerContext *context,
 grpc::Status Service::GetIgnoredNetworks(grpc::ServerContext *context,
                                          const proto::SnifferID *request,
                                          proto::NetworkList *reply) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->id()].get();
 
@@ -425,7 +425,7 @@ grpc::Status Service::GetIgnoredNetworks(grpc::ServerContext *context,
 grpc::Status Service::SaveDecryptedTraffic(grpc::ServerContext *context,
                                            const proto::NetworkName *request,
                                            proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -516,7 +516,7 @@ grpc::Status Service::LoadRecording(grpc::ServerContext *context,
 grpc::Status Service::SetMayhemMode(grpc::ServerContext *context,
                                     const proto::NewMayhemState *request,
                                     proto::Empty *reply) {
-  if (request->sniffer_id() > sniffers.size())
+  if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
@@ -554,7 +554,7 @@ grpc::Status Service::SetMayhemMode(grpc::ServerContext *context,
 grpc::Status Service::GetLED(grpc::ServerContext *context,
                              const proto::SnifferID *request,
                              grpc::ServerWriter<proto::LEDState> *writer) {
-  if (request->id() > sniffers.size())
+  if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->id()].get();
 

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -71,6 +71,7 @@ bool Service::add_iface_sniffer(const std::string &iface_name) {
 }
 
 void Service::shutdown() {
+  logger->info("Stopping the service");
   for (auto &sniffer : sniffers)
     sniffer->shutdown();
 }
@@ -107,6 +108,7 @@ grpc::Status Service::SnifferDestroy(grpc::ServerContext *context,
   if (request->id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   sniffers[request->id()]->shutdown();
+  erased_sniffers.push_back(std::move(sniffers[request->id()]));
   sniffers.erase(sniffers.begin() + request->id());
   return grpc::Status::OK;
 }

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -13,6 +13,8 @@ using group_window = yarilo::WPA2Decrypter::group_window;
 
 namespace yarilo {
 
+Service::Service() { logger = spdlog::stdout_color_mt("Service"); }
+
 Service::Service(std::unique_ptr<Tins::FileSniffer> sniffer) {
   logger = spdlog::stdout_color_mt("Service");
   sniffers.push_back(std::make_unique<Sniffer>(std::move(sniffer)));

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -22,29 +22,49 @@ public:
   bool add_iface_sniffer(const std::string &iface_name);
   void shutdown();
 
+  grpc::Status SnifferCreate(grpc::ServerContext *context,
+                             const proto::SnifferCreateRequest *request,
+                             proto::SnifferID *reply) override;
+
+  grpc::Status SnifferDestroy(grpc::ServerContext *context,
+                              const proto::SnifferID *request,
+                              proto::Empty *reply) override;
+
+  grpc::Status SnifferList(grpc::ServerContext *context,
+                           const proto::Empty *request,
+                           proto::SnifferListResponse *reply) override;
+
+  grpc::Status SniffFileList(grpc::ServerContext *context,
+                             const proto::Empty *request,
+                             proto::SniffFileListResponse *reply) override;
+
+  grpc::Status
+  SniffInterfaceList(grpc::ServerContext *context, const proto::Empty *request,
+                     proto::SniffInterfaceListResponse *reply) override;
+
   grpc::Status GetAllAccessPoints(grpc::ServerContext *context,
                                   const proto::SnifferID *request,
-                                  proto::NetworkList *response) override;
+                                  proto::NetworkList *reply) override;
 
   grpc::Status GetAccessPoint(grpc::ServerContext *context,
                               const proto::NetworkName *request,
-                              proto::NetworkInfo *response) override;
+                              proto::NetworkInfo *reply) override;
 
   grpc::Status FocusNetwork(grpc::ServerContext *context,
                             const proto::NetworkName *request,
-                            proto::Empty *response) override;
+                            proto::Empty *reply) override;
 
   grpc::Status GetFocusState(grpc::ServerContext *context,
                              const proto::SnifferID *request,
-                             proto::FocusState *response) override;
+                             proto::FocusState *reply) override;
 
   grpc::Status StopFocus(grpc::ServerContext *context,
                          const proto::SnifferID *request,
-                         proto::Empty *response) override;
+                         proto::Empty *reply) override;
 
   grpc::Status ProvidePassword(grpc::ServerContext *context,
                                const proto::DecryptRequest *request,
-                               proto::Empty *response) override;
+                               proto::Empty *reply) override;
 
   grpc::Status
   GetDecryptedPackets(grpc::ServerContext *context,
@@ -53,23 +73,23 @@ public:
 
   grpc::Status DeauthNetwork(grpc::ServerContext *context,
                              const proto::DeauthRequest *request,
-                             proto::Empty *response) override;
+                             proto::Empty *reply) override;
 
   grpc::Status IgnoreNetwork(grpc::ServerContext *context,
                              const proto::NetworkName *request,
-                             proto::Empty *response) override;
+                             proto::Empty *reply) override;
 
   grpc::Status GetIgnoredNetworks(grpc::ServerContext *context,
                                   const proto::SnifferID *request,
-                                  proto::NetworkList *response) override;
+                                  proto::NetworkList *reply) override;
 
   grpc::Status SaveDecryptedTraffic(grpc::ServerContext *context,
                                     const proto::NetworkName *request,
-                                    proto::Empty *response) override;
+                                    proto::Empty *reply) override;
 
   grpc::Status GetAvailableRecordings(grpc::ServerContext *context,
                                       const proto::Empty *request,
-                                      proto::RecordingsList *response) override;
+                                      proto::RecordingsList *reply) override;
 
   grpc::Status
   LoadRecording(grpc::ServerContext *context, const proto::File *request,
@@ -77,7 +97,7 @@ public:
 
   grpc::Status SetMayhemMode(grpc::ServerContext *context,
                              const proto::NewMayhemState *request,
-                             proto::Empty *response) override;
+                             proto::Empty *reply) override;
 
   grpc::Status GetLED(grpc::ServerContext *context,
                       const proto::SnifferID *request,

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -105,6 +105,8 @@ public:
 
 private:
   std::vector<std::unique_ptr<Sniffer>> sniffers;
+  std::vector<std::unique_ptr<Sniffer>>
+      erased_sniffers; // Kept for shutdown logic
   std::shared_ptr<spdlog::logger> logger;
   const std::filesystem::path save_path;
   const std::filesystem::path sniff_path;

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -15,6 +15,7 @@ namespace yarilo {
  */
 class Service : public proto::Sniffer::Service {
 public:
+  Service();
   Service(std::unique_ptr<Tins::FileSniffer>);
   Service(std::unique_ptr<Tins::Sniffer>, const Tins::NetworkInterface &iface);
 

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -15,13 +15,12 @@ namespace yarilo {
  */
 class Service : public proto::Sniffer::Service {
 public:
-  Service();
-  Service(std::unique_ptr<Tins::FileSniffer>);
-  Service(std::unique_ptr<Tins::Sniffer>, const Tins::NetworkInterface &iface);
+  Service(const std::filesystem::path &save_path,
+          const std::filesystem::path &sniff_path);
 
-  void start();
+  bool add_file_sniffer(const std::filesystem::path &file);
+  bool add_iface_sniffer(const std::string &iface_name);
   void shutdown();
-  void add_save_path(const std::filesystem::path &path);
 
   grpc::Status GetAllAccessPoints(grpc::ServerContext *context,
                                   const proto::SnifferID *request,
@@ -87,9 +86,8 @@ public:
 private:
   std::vector<std::unique_ptr<Sniffer>> sniffers;
   std::shared_ptr<spdlog::logger> logger;
-  bool filemode = true;
-  Tins::NetworkInterface iface;
-  std::filesystem::path save_path = "/tmp/yarilo";
+  const std::filesystem::path save_path;
+  const std::filesystem::path sniff_path;
 
 #ifdef MAYHEM
   std::atomic<bool> led_on = false;

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -2,6 +2,7 @@
 #include "decrypter.h"
 #include <absl/strings/str_format.h>
 #include <net/if.h>
+#include <optional>
 #include <tins/sniffer.h>
 
 namespace yarilo {
@@ -135,6 +136,12 @@ void Sniffer::shutdown() {
   finished.store(true);
   for (auto &[_, ap] : aps)
     ap->close_all_channels();
+}
+
+std::optional<Tins::NetworkInterface> Sniffer::iface() {
+  if (!filemode)
+    return std::nullopt;
+  return send_iface;
 }
 
 bool Sniffer::focus_network(const SSID &ssid) {

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -7,10 +7,12 @@
 
 namespace yarilo {
 
-Sniffer::Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer) {
+Sniffer::Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer,
+                 const std::filesystem::path &filepath) {
   logger = spdlog::stdout_color_mt("Sniffer");
   this->sniffer = std::move(sniffer);
   this->finished.store(false);
+  this->filepath = filepath;
 }
 
 Sniffer::Sniffer(std::unique_ptr<Tins::Sniffer> sniffer,
@@ -142,6 +144,12 @@ std::optional<Tins::NetworkInterface> Sniffer::iface() {
   if (!filemode)
     return std::nullopt;
   return send_iface;
+}
+
+std::optional<std::filesystem::path> Sniffer::file() {
+  if (!filemode)
+    return std::nullopt;
+  return filepath;
 }
 
 bool Sniffer::focus_network(const SSID &ssid) {

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -2,10 +2,17 @@
 #include "decrypter.h"
 #include <absl/strings/str_format.h>
 #include <net/if.h>
+#include <tins/sniffer.h>
 
 namespace yarilo {
 
-Sniffer::Sniffer(std::unique_ptr<Tins::BaseSniffer> sniffer,
+Sniffer::Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer) {
+  logger = spdlog::stdout_color_mt("Sniffer");
+  this->sniffer = std::move(sniffer);
+  this->finished.store(false);
+}
+
+Sniffer::Sniffer(std::unique_ptr<Tins::Sniffer> sniffer,
                  const Tins::NetworkInterface &iface) {
   logger = spdlog::stdout_color_mt("Sniffer");
   this->send_iface = iface;
@@ -13,12 +20,6 @@ Sniffer::Sniffer(std::unique_ptr<Tins::BaseSniffer> sniffer,
   this->sniffer = std::move(sniffer);
   this->finished.store(false);
   this->net_manager.connect();
-}
-
-Sniffer::Sniffer(std::unique_ptr<Tins::BaseSniffer> sniffer) {
-  logger = spdlog::stdout_color_mt("Sniffer");
-  this->sniffer = std::move(sniffer);
-  this->finished.store(false);
 }
 
 void Sniffer::start() {

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -33,14 +33,14 @@ public:
    * A constructor to create the Sniffer without network card support
    * @param[in] sniffer `Tins::FileSniffer` instance
    */
-  Sniffer(std::unique_ptr<Tins::BaseSniffer> sniffer);
+  Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer);
 
   /**
    * A constructor to create the Sniffer with network card support
    * @param[in] sniffer `Tins::Sniffer` instance
    * @param[in] iface Network interface to use
    */
-  Sniffer(std::unique_ptr<Tins::BaseSniffer> sniffer,
+  Sniffer(std::unique_ptr<Tins::Sniffer> sniffer,
           const Tins::NetworkInterface &iface);
 
   /**

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -108,7 +108,7 @@ public:
    * Get the used interface (if applicable)
    * @return Used net logical interface
    */
-  std::optional<Tins::NetworkInterface> iface();
+  std::optional<std::string> iface();
 
   /**
    * Get the used filepath (if applicable)
@@ -246,6 +246,7 @@ private:
   std::unique_ptr<Tins::Crypto::WPA2Decrypter> decrypter;
   std::map<MACAddress, std::shared_ptr<AccessPoint>> aps;
   Tins::NetworkInterface send_iface;
+  std::string iface_name = "";
   std::filesystem::path filepath;
   std::set<SSID> ignored_net_names;
   std::set<MACAddress> ignored_net_addrs;

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -33,7 +33,8 @@ public:
    * A constructor to create the Sniffer without network card support
    * @param[in] sniffer `Tins::FileSniffer` instance
    */
-  Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer);
+  Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer,
+          const std::filesystem::path &filepath);
 
   /**
    * A constructor to create the Sniffer with network card support
@@ -110,9 +111,15 @@ public:
   std::optional<Tins::NetworkInterface> iface();
 
   /**
+   * Get the used filepath (if applicable)
+   * @return Used filepath
+   */
+  std::optional<std::filesystem::path> file();
+
+  /**
    * Focus a specific network by SSID
-   * @param[in] ssid Sevice set identifier of the network to be focused (network
-   * name)
+   * @param[in] ssid Sevice set identifier of the network to be focused
+   * (network name)
    * @return True if the operation was successful, false otherwise
    */
   bool focus_network(const SSID &ssid);
@@ -239,6 +246,7 @@ private:
   std::unique_ptr<Tins::Crypto::WPA2Decrypter> decrypter;
   std::map<MACAddress, std::shared_ptr<AccessPoint>> aps;
   Tins::NetworkInterface send_iface;
+  std::filesystem::path filepath;
   std::set<SSID> ignored_net_names;
   std::set<MACAddress> ignored_net_addrs;
   std::unique_ptr<Tins::BaseSniffer> sniffer;

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -104,6 +104,12 @@ public:
   void shutdown();
 
   /**
+   * Get the used interface (if applicable)
+   * @return Used net logical interface
+   */
+  std::optional<Tins::NetworkInterface> iface();
+
+  /**
    * Focus a specific network by SSID
    * @param[in] ssid Sevice set identifier of the network to be focused (network
    * name)

--- a/frontend/src/lib/components/aplist.svelte
+++ b/frontend/src/lib/components/aplist.svelte
@@ -16,7 +16,7 @@
 	import { onMount } from 'svelte';
 
 	const displayError = (error: RpcError) => {
-		console.error('Error!', error);
+		console.error('Error!', error.toString());
 		errMsg = error.code;
 		setTimeout(() => {
 			errMsg = null;
@@ -26,7 +26,7 @@
 	const refreshAccessPoints = () => {
 		ensureConnected().then(() => {
 			$client
-				.getAllAccessPoints({})
+				.getAllAccessPoints({ id: 0n })
 				.then((data: FinishedUnaryCall<Empty, NetworkList>) => {
 					console.log('New network list fetched!', networkList);
 					networkList = data.response.names;
@@ -38,7 +38,7 @@
 	const focusNetwork = (ap: string) => {
 		ensureConnected().then(() => {
 			$client
-				.focusNetwork({ ssid: ap })
+				.focusNetwork({ snifferId: 0n, ssid: ap })
 				.then(() => {
 					console.log('Network focused!', ap);
 					focusedNetwork = ap;
@@ -50,7 +50,7 @@
 	const unfocusNetwork = () => {
 		ensureConnected().then(() => {
 			$client
-				.stopFocus({})
+				.stopFocus({ id: 0n })
 				.then(() => {
 					console.log('Network unfocused!');
 					focusedNetwork = null;
@@ -63,7 +63,7 @@
 		// If we are mounting client-side, then run this
 		ensureConnected().then(() => {
 			$client
-				.getFocusState({})
+				.getFocusState({ id: 0n })
 				.then((data: FinishedUnaryCall<Empty, FocusState>) => {
 					console.log('Got network focus from the server');
 					if (data.response.focused && data.response.name) {
@@ -83,7 +83,7 @@
 	});
 </script>
 
-<div class="w-1/6 flex flex-col rounded-xl border bg-primary p-4 text-primary-foreground">
+<div class="flex w-1/6 flex-col rounded-xl border bg-primary p-4 text-primary-foreground">
 	<div class="mb-6 mt-1 flex h-4 items-center justify-between">
 		{#if focusedNetwork}
 			<h4 class="text-md px-2 font-medium leading-none">Focused: {focusedNetwork}</h4>
@@ -96,10 +96,10 @@
 	</div>
 
 	{#each networkList as ap}
-		<div class="w-64 mx-2 flex items-center justify-between">
+		<div class="mx-2 flex w-64 items-center justify-between">
 			<Label for={ap}>{ap}</Label>
 			<Switch id={ap} onCheckedChange={changeChecked(ap)} />
 		</div>
-		<Separator class="w-64 my-2" />
+		<Separator class="my-2 w-64" />
 	{/each}
 </div>

--- a/protos/packets.proto
+++ b/protos/packets.proto
@@ -5,6 +5,21 @@ package proto;
 // The Sniffer service is responsible capturing data from a file or a network
 // interface card and relaying the data to clients.
 service Sniffer {
+  // Create a sniffer instance
+  rpc SnifferCreate(SnifferCreateRequest) returns (SnifferID) {}
+
+  // Create a sniffer instance
+  rpc SnifferDestroy(SnifferID) returns (Empty) {}
+
+  // List active sniffers
+  rpc SnifferList(Empty) returns (SnifferListResponse) {}
+
+  // List sniffer files (pcap recordings of 802.11 networks)
+  rpc SniffFileList(Empty) returns (SniffFileListResponse) {}
+
+  // List interfaces that can be used for sniffing
+  rpc SniffInterfaceList(Empty) returns (SniffInterfaceListResponse) {}
+
   // Get all discovered access points.
   rpc GetAllAccessPoints(SnifferID) returns (NetworkList) {}
 
@@ -49,18 +64,6 @@ service Sniffer {
 
   // Enable the LED on the server and subscribe to the LED updates.
   rpc GetLED(SnifferID) returns (stream LEDState) {}
-
-  // Create a sniffer instance
-  rpc SnifferCreate(SnifferCreateRequest) returns (SnifferID) {}
-
-  // List active sniffers
-  rpc SnifferList(Empty) returns (SnifferListResponse) {}
-
-  // List sniffer files (pcap recordings of 802.11 networks)
-  rpc SniffFileList(Empty) returns (SniffFileListResponse) {}
-
-  // List interfaces that can be used for sniffing
-  rpc SniffInterfaceList(Empty) returns (SniffInterfaceListResponse) {}
 }
 
 // Empty message, it exists since we can't send no arguments or receive no
@@ -78,12 +81,12 @@ message SnifferCreateRequest {
 }
 
 // List many sniffers
-message SnifferListResponse { repeated SnifferInfo snffers = 1; }
+message SnifferListResponse { repeated SnifferInfo sniffers = 1; }
 message SnifferInfo {
   int64 id = 1;
   string name = 2;
   bool is_file_based = 3;
-  bool net_iface_name = 4;
+  string net_iface_name = 4;
   string filename = 5;
 }
 

--- a/protos/packets.proto
+++ b/protos/packets.proto
@@ -6,7 +6,7 @@ package proto;
 // interface card and relaying the data to clients.
 service Sniffer {
   // Get all discovered access points.
-  rpc GetAllAccessPoints(Empty) returns (NetworkList) {}
+  rpc GetAllAccessPoints(SnifferID) returns (NetworkList) {}
 
   // Get a specific access point.
   rpc GetAccessPoint(NetworkName) returns (NetworkInfo) {}
@@ -15,10 +15,10 @@ service Sniffer {
   rpc FocusNetwork(NetworkName) returns (Empty) {}
 
   // Get information whether any access point is being focused.
-  rpc GetFocusState(Empty) returns (FocusState) {}
+  rpc GetFocusState(SnifferID) returns (FocusState) {}
 
   // Stop focusing an access point.
-  rpc StopFocus(Empty) returns (Empty) {}
+  rpc StopFocus(SnifferID) returns (Empty) {}
 
   // Decryption & getting handshakes
   rpc ProvidePassword(DecryptRequest) returns (Empty) {}
@@ -33,7 +33,7 @@ service Sniffer {
   rpc IgnoreNetwork(NetworkName) returns (Empty) {}
 
   // Get all the ignored networks.
-  rpc GetIgnoredNetworks(Empty) returns (NetworkList) {}
+  rpc GetIgnoredNetworks(SnifferID) returns (NetworkList) {}
 
   // Save the decrypted stream from a network to a file.
   rpc SaveDecryptedTraffic(NetworkName) returns (Empty) {}
@@ -48,15 +48,54 @@ service Sniffer {
   rpc SetMayhemMode(NewMayhemState) returns (Empty) {}
 
   // Enable the LED on the server and subscribe to the LED updates.
-  rpc GetLED(Empty) returns (stream LEDState) {}
+  rpc GetLED(SnifferID) returns (stream LEDState) {}
+
+  // Create a sniffer instance
+  rpc SnifferCreate(SnifferCreateRequest) returns (SnifferID) {}
+
+  // List active sniffers
+  rpc SnifferList(Empty) returns (SnifferListResponse) {}
+
+  // List sniffer files (pcap recordings of 802.11 networks)
+  rpc SniffFileList(Empty) returns (SniffFileListResponse) {}
+
+  // List interfaces that can be used for sniffing
+  rpc SniffInterfaceList(Empty) returns (SniffInterfaceListResponse) {}
 }
 
 // Empty message, it exists since we can't send no arguments or receive no
 // data
 message Empty {}
 
+// Specify the sniffer ID
+message SnifferID { int64 id = 1; }
+
+// Create a sniffer
+message SnifferCreateRequest {
+  bool is_file_based = 1;
+  string net_iface_name = 2;
+  string filename = 3;
+}
+
+// List many sniffers
+message SnifferListResponse { repeated SnifferInfo snffers = 1; }
+message SnifferInfo {
+  int64 id = 1;
+  string name = 2;
+  bool is_file_based = 3;
+  bool net_iface_name = 4;
+  string filename = 5;
+}
+
+// List available files or logical interfaces
+message SniffFileListResponse { repeated string filename = 1; }
+message SniffInterfaceListResponse { repeated string net_iface_name = 1; }
+
 // Network name denoted by its ssid
-message NetworkName { string ssid = 1; }
+message NetworkName {
+  int64 sniffer_id = 1;
+  string ssid = 2;
+}
 
 // User of a wireless netwokr (in tcp/udp packet streams)
 message User {
@@ -76,8 +115,9 @@ message Packet {
 
 // Add a user MAC to the deauth request
 message DeauthRequest {
-  NetworkName network = 1;
-  string user_addr = 2;
+  int64 sniffer_id = 1;
+  NetworkName network = 2;
+  string user_addr = 3;
 }
 
 // List of networks
@@ -85,8 +125,9 @@ message NetworkList { repeated string names = 1; }
 
 // Decryption request
 message DecryptRequest {
-  string ssid = 1;
-  string passwd = 2;
+  int64 sniffer_id = 1;
+  string ssid = 2;
+  string passwd = 3;
 }
 
 // Access Point information
@@ -115,13 +156,19 @@ message FocusState {
 }
 
 // Information about a file
-message File { string name = 1; }
+message File {
+  int64 sniffer_id = 1;
+  string name = 2;
+}
 
 // List of available recordings
 message RecordingsList { repeated File files = 1; }
 
 // Set mayhem (deauthing all networks)
-message NewMayhemState { bool state = 1; }
+message NewMayhemState {
+  int64 sniffer_id = 1;
+  bool state = 2;
+}
 
 // Color of the LED
 enum Color {


### PR DESCRIPTION
# Added

- Sniffers can now be added on-the-fly from the endpoints (file and interface) - solves #47 
- Commands can be sent per-sniffer

# Changed

- gRPC requests should now include the `ID` of the sniffer. Look at `proto/packets.proto` for more info