### PR TITLE
Save raw traffic

### DIFF
--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -26,6 +26,7 @@ AccessPoint::AccessPoint(const MACAddress &bssid, const SSID &ssid,
 };
 
 bool AccessPoint::handle_pkt(Tins::Packet *pkt) {
+  count++;
   auto pdu = pkt->pdu();
   if (pdu->find_pdu<Tins::Dot11Data>())
     return handle_data(pkt);
@@ -214,6 +215,10 @@ bool AccessPoint::handle_data(Tins::Packet *pkt) {
 }
 
 bool AccessPoint::handle_management(Tins::Packet *pkt) {
+  if (count == 1)
+    captured_packets.push_back(
+        pkt); // First pkt is always network ID (Beacon/ProbeResp)
+
   auto mgmt = pkt->pdu()->rfind_pdu<Tins::Dot11ManagementFrame>();
   if (mgmt.wep())
     pmf_supported = true;

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -4,6 +4,7 @@
 #include "channel.h"
 #include "decrypter.h"
 #include <filesystem>
+#include <tins/ethernetII.h>
 #include <tins/tins.h>
 #include <vector>
 
@@ -94,7 +95,7 @@ public:
    * Get the converted data channel for this network
    * TODO: Add timing info
    */
-  std::shared_ptr<PacketChannel> get_channel();
+  std::shared_ptr<PacketChannel> get_decrypted_channel();
 
   /**
    * Close all channels
@@ -173,11 +174,19 @@ public:
   int decrypted_packet_count() const;
 
   /**
+   * Save all traffic (in 802.11 data link)
+   * @param[in] directory in which the recording should live
+   * @return optionally number of packets saved
+   */
+  std::optional<uint32_t> save_traffic(const std::filesystem::path &save_path);
+
+  /**
    * Save decrypted traffic
    * @param[in] directory in which the recording should live
-   * @return True if the traffic was saved successfully
+   * @return optionally number of packets saved
    */
-  bool save_decrypted_traffic(const std::filesystem::path &save_path);
+  std::optional<uint32_t>
+  save_decrypted_traffic(const std::filesystem::path &save_path);
 
 private:
   /**
@@ -204,14 +213,6 @@ private:
    * @param[in] mgtm A reference to a management packet
    */
   bool is_ccmp(const Tins::Dot11ManagementFrame &mgmt) const;
-
-  /**
-   * Create an ethernet packet based on the decrypted 802.11 packet
-   * @param[in] data The 802.11 packet to convert
-   * @return The converted ethernet packet
-   */
-  static std::unique_ptr<Tins::EthernetII>
-  make_eth_packet(Tins::Dot11Data *data);
 
   std::shared_ptr<spdlog::logger> logger;
   const SSID ssid;

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -214,6 +214,7 @@ private:
    */
   bool is_ccmp(const Tins::Dot11ManagementFrame &mgmt) const;
 
+  int count = 0;
   std::shared_ptr<spdlog::logger> logger;
   const SSID ssid;
   const MACAddress bssid;

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -1,8 +1,11 @@
 #include "service.h"
+#include "packets.pb.h"
 #include <grpcpp/support/status.h>
 #include <memory>
+#include <tins/ethernetII.h>
 #include <tins/ip.h>
 #include <tins/network_interface.h>
+#include <tins/packet.h>
 #include <tins/packet_sender.h>
 #include <tins/pdu.h>
 #include <tins/sniffer.h>
@@ -321,7 +324,7 @@ Service::GetDecryptedPackets(grpc::ServerContext *context,
                         "No network with this ssid");
 
   // Make sure to cancel when the user cancels!
-  std::shared_ptr<PacketChannel> channel = ap.value()->get_channel();
+  std::shared_ptr<PacketChannel> channel = ap.value()->get_decrypted_channel();
   std::thread([context, channel]() {
     while (true) {
       if (context->IsCancelled()) {
@@ -335,31 +338,31 @@ Service::GetDecryptedPackets(grpc::ServerContext *context,
 
   logger->trace("Streaming packets");
   while (!channel->is_closed()) {
-    std::optional<std::unique_ptr<Tins::EthernetII>> pkt_opt =
-        channel->receive();
+    std::optional<std::unique_ptr<Tins::Packet>> pkt_opt = channel->receive();
     if (!pkt_opt.has_value()) {
       logger->trace("Stream has been cancelled");
       return grpc::Status::OK;
     }
 
-    std::unique_ptr<Tins::EthernetII> pkt = std::move(pkt_opt.value());
-    auto ip = pkt->find_pdu<Tins::IP>();
+    std::unique_ptr<Tins::Packet> pkt = std::move(pkt_opt.value());
+    auto eth2 = pkt->pdu()->find_pdu<Tins::EthernetII>();
+    auto ip = pkt->pdu()->find_pdu<Tins::IP>();
     if (!ip)
       continue;
 
-    auto tcp = pkt->find_pdu<Tins::TCP>();
-    auto udp = pkt->find_pdu<Tins::UDP>();
+    auto tcp = pkt->pdu()->find_pdu<Tins::TCP>();
+    auto udp = pkt->pdu()->find_pdu<Tins::UDP>();
     if (!tcp && !udp)
       continue;
 
     auto from = std::make_unique<proto::User>();
     from->set_ipv4address(ip->src_addr().to_string());
-    from->set_macaddress(pkt->src_addr().to_string());
+    from->set_macaddress(eth2->src_addr().to_string());
     from->set_port(tcp ? tcp->sport() : udp->sport());
 
     auto to = std::make_unique<proto::User>();
     to->set_ipv4address(ip->dst_addr().to_string());
-    to->set_macaddress(pkt->dst_addr().to_string());
+    to->set_macaddress(eth2->dst_addr().to_string());
     to->set_port(tcp ? tcp->dport() : udp->dport());
 
     auto packet = std::make_unique<proto::Packet>();
@@ -434,23 +437,43 @@ grpc::Status Service::GetIgnoredNetworks(grpc::ServerContext *context,
   return grpc::Status::OK;
 };
 
-grpc::Status Service::SaveDecryptedTraffic(grpc::ServerContext *context,
-                                           const proto::NetworkName *request,
-                                           proto::Empty *reply) {
+grpc::Status
+Service::RecordingCreate(grpc::ServerContext *context,
+                         const proto::RecordingCreateRequest *request,
+                         proto::RecordingCreateResponse *reply) {
   if (request->sniffer_id() >= sniffers.size())
     return grpc::Status(grpc::StatusCode::NOT_FOUND, "No sniffer with this id");
   Sniffer *sniffer = sniffers[request->sniffer_id()].get();
 
-  auto ap = sniffer->get_network(request->ssid());
-  if (!ap.has_value())
-    return grpc::Status(grpc::StatusCode::NOT_FOUND,
-                        "No network with this ssid");
+  if (request->singular_ap()) {
+    auto ap = sniffer->get_network(request->ssid());
+    if (!ap.has_value())
+      return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                          "No network with this ssid");
 
-  bool saved = ap.value()->save_decrypted_traffic(save_path);
-  if (!saved)
+    if (request->data_link() == proto::DataLinkType::DOT11) {
+      if (!ap.value()->save_traffic(save_path))
+        return grpc::Status(grpc::StatusCode::INTERNAL,
+                            "Cannot save decrypted traffic");
+      return grpc::Status::OK;
+    }
+
+    if (!ap.value()->save_decrypted_traffic(save_path))
+      return grpc::Status(grpc::StatusCode::INTERNAL,
+                          "Cannot save decrypted traffic");
+    return grpc::Status::OK;
+  }
+
+  if (request->data_link() == proto::DataLinkType::DOT11) {
+    if (sniffer->save_traffic(save_path))
+      return grpc::Status(grpc::StatusCode::INTERNAL,
+                          "Cannot save decrypted traffic");
+    return grpc::Status::OK;
+  }
+
+  if (sniffer->save_decrypted_traffic(save_path))
     return grpc::Status(grpc::StatusCode::INTERNAL,
                         "Cannot save decrypted traffic");
-
   return grpc::Status::OK;
 };
 
@@ -484,29 +507,29 @@ grpc::Status Service::LoadRecording(grpc::ServerContext *context,
 
   while (iter_count != channel->len()) {
     iter_count++;
-    std::optional<std::unique_ptr<Tins::EthernetII>> pkt_opt =
-        channel->receive();
+    std::optional<std::unique_ptr<Tins::Packet>> pkt_opt = channel->receive();
     if (!pkt_opt.has_value())
       return grpc::Status::OK;
 
-    std::unique_ptr<Tins::EthernetII> pkt = std::move(pkt_opt.value());
-    auto ip = pkt->find_pdu<Tins::IP>();
+    std::unique_ptr<Tins::Packet> pkt = std::move(pkt_opt.value());
+    auto eth2 = pkt->pdu()->find_pdu<Tins::EthernetII>();
+    auto ip = pkt->pdu()->find_pdu<Tins::IP>();
     if (!ip)
       continue;
 
-    auto tcp = pkt->find_pdu<Tins::TCP>();
-    auto udp = pkt->find_pdu<Tins::UDP>();
+    auto tcp = pkt->pdu()->find_pdu<Tins::TCP>();
+    auto udp = pkt->pdu()->find_pdu<Tins::UDP>();
     if (!tcp && !udp)
       continue;
 
     auto from = std::make_unique<proto::User>();
     from->set_ipv4address(ip->src_addr().to_string());
-    from->set_macaddress(pkt->src_addr().to_string());
+    from->set_macaddress(eth2->src_addr().to_string());
     from->set_port(tcp ? tcp->sport() : udp->sport());
 
     auto to = std::make_unique<proto::User>();
     to->set_ipv4address(ip->dst_addr().to_string());
-    to->set_macaddress(pkt->dst_addr().to_string());
+    to->set_macaddress(eth2->dst_addr().to_string());
     to->set_port(tcp ? tcp->dport() : udp->dport());
 
     auto packet = std::make_unique<proto::Packet>();

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -452,28 +452,41 @@ Service::RecordingCreate(grpc::ServerContext *context,
                           "No network with this ssid");
 
     if (request->data_link() == proto::DataLinkType::DOT11) {
-      if (!ap.value()->save_traffic(save_path))
+      std::optional<uint32_t> count = ap.value()->save_traffic(save_path);
+      if (!count.has_value())
         return grpc::Status(grpc::StatusCode::INTERNAL,
                             "Cannot save decrypted traffic");
+
+      reply->set_packet_count(count.value());
       return grpc::Status::OK;
     }
 
-    if (!ap.value()->save_decrypted_traffic(save_path))
+    std::optional<uint32_t> count =
+        ap.value()->save_decrypted_traffic(save_path);
+    if (!count.has_value())
       return grpc::Status(grpc::StatusCode::INTERNAL,
                           "Cannot save decrypted traffic");
+
+    reply->set_packet_count(count.value());
     return grpc::Status::OK;
   }
 
   if (request->data_link() == proto::DataLinkType::DOT11) {
-    if (sniffer->save_traffic(save_path))
+    std::optional<uint32_t> count = sniffer->save_traffic(save_path);
+    if (!count.has_value())
       return grpc::Status(grpc::StatusCode::INTERNAL,
                           "Cannot save decrypted traffic");
+
+    reply->set_packet_count(count.value());
     return grpc::Status::OK;
   }
 
-  if (sniffer->save_decrypted_traffic(save_path))
+  std::optional<uint32_t> count = sniffer->save_decrypted_traffic(save_path);
+  if (!count.has_value())
     return grpc::Status(grpc::StatusCode::INTERNAL,
                         "Cannot save decrypted traffic");
+
+  reply->set_packet_count(count.value());
   return grpc::Status::OK;
 };
 

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -83,9 +83,9 @@ public:
                                   const proto::SnifferID *request,
                                   proto::NetworkList *reply) override;
 
-  grpc::Status SaveDecryptedTraffic(grpc::ServerContext *context,
-                                    const proto::NetworkName *request,
-                                    proto::Empty *reply) override;
+  grpc::Status RecordingCreate(grpc::ServerContext *context,
+                               const proto::RecordingCreateRequest *request,
+                               proto::RecordingCreateResponse *reply) override;
 
   grpc::Status GetAvailableRecordings(grpc::ServerContext *context,
                                       const proto::Empty *request,

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -1,9 +1,12 @@
 #include "sniffer.h"
 #include "decrypter.h"
+#include "utils.h"
 #include <absl/strings/str_format.h>
+#include <memory>
 #include <net/if.h>
 #include <optional>
 #include <spdlog/spdlog.h>
+#include <tins/packet.h>
 #include <tins/sniffer.h>
 
 using phy_info = yarilo::NetCardManager::phy_info;
@@ -197,6 +200,34 @@ void Sniffer::stop_focus() {
   return;
 }
 
+std::optional<uint32_t>
+Sniffer::save_traffic(const std::filesystem::path &dir_path) {
+  logger->debug("Creating a raw recording with {} packets", packets.size());
+  Recording rec(dir_path, true);
+
+  std::shared_ptr<PacketChannel> channel;
+  for (const auto &pkt : packets)
+    channel->send(std::make_unique<Tins::Packet>(pkt));
+  return rec.dump(std::move(channel));
+}
+
+std::optional<uint32_t>
+Sniffer::save_decrypted_traffic(const std::filesystem::path &dir_path) {
+  logger->debug("Creating a raw recording with {} packets", packets.size());
+  Recording rec(dir_path, false);
+
+  std::shared_ptr<PacketChannel> channel;
+  for (auto &pkt : packets) {
+    // Check if decrypted
+    auto data = pkt.pdu()->find_pdu<Tins::Dot11Data>();
+    if (!data || !data->find_pdu<Tins::SNAP>())
+      continue;
+    channel->send(Recording::make_eth_packet(&pkt));
+  }
+
+  return rec.dump(std::move(channel));
+}
+
 void Sniffer::hopper(const std::string &phy_name,
                      const std::vector<uint32_t> &channels) {
   while (!finished.load()) {
@@ -383,13 +414,13 @@ Sniffer::get_recording_stream(const std::filesystem::path &save_path,
   auto chan = std::make_unique<PacketChannel>();
   int pkt_count = 0;
 
-  temp_sniff->sniff_loop([&chan, &pkt_count, this](Tins::PDU &pkt) {
-    auto eth = pkt.find_pdu<Tins::EthernetII>();
+  temp_sniff->sniff_loop([&chan, &pkt_count, this](Tins::Packet &pkt) {
+    auto eth = pkt.pdu()->find_pdu<Tins::EthernetII>();
     if (eth == nullptr)
       return true;
 
     pkt_count++;
-    chan->send(std::unique_ptr<Tins::EthernetII>(eth->clone()));
+    chan->send(std::unique_ptr<Tins::Packet>(&pkt));
     return true;
   });
 

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -358,7 +358,7 @@ bool Sniffer::handle_management(Tins::Packet &pkt) {
     SSID ssid = (has_ssid_info) ? mgmt.ssid() : bssid.to_string();
     int channel = (has_channel_info) ? mgmt.ds_parameter_set() : 1;
     aps[bssid] = std::make_shared<AccessPoint>(bssid, ssid, channel);
-    return true;
+    return aps[bssid]->handle_pkt(save_pkt(pkt));
   }
 
   if (aps.count(bssid))

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -205,7 +205,7 @@ Sniffer::save_traffic(const std::filesystem::path &dir_path) {
   logger->debug("Creating a raw recording with {} packets", packets.size());
   Recording rec(dir_path, true);
 
-  std::shared_ptr<PacketChannel> channel;
+  auto channel = std::make_unique<PacketChannel>();
   for (const auto &pkt : packets)
     channel->send(std::make_unique<Tins::Packet>(pkt));
   return rec.dump(std::move(channel));
@@ -213,10 +213,9 @@ Sniffer::save_traffic(const std::filesystem::path &dir_path) {
 
 std::optional<uint32_t>
 Sniffer::save_decrypted_traffic(const std::filesystem::path &dir_path) {
-  logger->debug("Creating a raw recording with {} packets", packets.size());
   Recording rec(dir_path, false);
 
-  std::shared_ptr<PacketChannel> channel;
+  auto channel = std::make_unique<PacketChannel>();
   for (auto &pkt : packets) {
     // Check if decrypted
     auto data = pkt.pdu()->find_pdu<Tins::Dot11Data>();
@@ -225,6 +224,8 @@ Sniffer::save_decrypted_traffic(const std::filesystem::path &dir_path) {
     channel->send(Recording::make_eth_packet(&pkt));
   }
 
+  logger->debug("Creating a decrypted recording with {} packets",
+                channel->len());
   return rec.dump(std::move(channel));
 }
 

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -144,6 +144,21 @@ public:
   void stop_focus();
 
   /**
+   * Save all traffic (in 802.11 data link)
+   * @param[in] directory in which the recording should live
+   * @return optionally number of packets saved
+   */
+  std::optional<uint32_t> save_traffic(const std::filesystem::path &save_path);
+
+  /**
+   * Save decrypted traffic
+   * @param[in] directory in which the recording should live
+   * @return optionally number of packets saved
+   */
+  std::optional<uint32_t>
+  save_decrypted_traffic(const std::filesystem::path &save_path);
+
+  /**
    * Get the recordings available in the saves directory
    * @param[in] save_path Path where the recordings are stored
    * @return Recording filenames to choose from

--- a/backend/src/utils.h
+++ b/backend/src/utils.h
@@ -1,0 +1,117 @@
+#ifndef SNIFF_UTILS
+#define SNIFF_UTILS
+
+#include "channel.h"
+#include "decrypter.h"
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <tins/data_link_type.h>
+#include <tins/ethernetII.h>
+#include <tins/packet_writer.h>
+#include <tins/snap.h>
+
+namespace yarilo {
+
+/**
+ * @brief Recordings utility class
+ */
+class Recording {
+public:
+  Recording(const std::filesystem::path &save_dir, bool dump_raw)
+      : save_dir(save_dir), dump_raw(dump_raw) {}
+
+  void set_name(const std::string &basename) { this->basename = basename; }
+
+  std::optional<uint32_t> dump(std::shared_ptr<PacketChannel> channel) {
+    if (channel->is_closed())
+      return std::nullopt;
+
+    channel->lock_send();
+    std::unique_ptr<Tins::PacketWriter> writer;
+    if (dump_raw) {
+      writer = std::make_unique<Tins::PacketWriter>(
+          generate_path().string(), Tins::DataLinkType<Tins::Dot11>());
+    } else {
+      writer = std::make_unique<Tins::PacketWriter>(
+          generate_path().string(), Tins::DataLinkType<Tins::EthernetII>());
+    }
+
+    uint32_t count = 0;
+    std::thread watcher([this, &channel, &count]() {
+      while (!channel->is_empty())
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      channel->close();
+    });
+
+    while (!channel->is_closed()) {
+      auto pkt = channel->receive();
+      if (!pkt.has_value())
+        break;
+      count++;
+      writer->write(pkt.value());
+    }
+
+    channel->unlock_send();
+    watcher.join();
+    return count;
+  }
+
+  std::optional<uint32_t> dump(std::vector<Tins::Packet *> *packets) {
+    const auto path = generate_path();
+    std::unique_ptr<Tins::PacketWriter> writer;
+    if (dump_raw) {
+      writer = std::make_unique<Tins::PacketWriter>(
+          generate_path().string(), Tins::DataLinkType<Tins::Dot11>());
+    } else {
+      writer = std::make_unique<Tins::PacketWriter>(
+          generate_path().string(), Tins::DataLinkType<Tins::EthernetII>());
+    }
+
+    uint32_t count = 0;
+    for (const auto &pkt : *packets) {
+      count++;
+      writer->write(pkt);
+    }
+
+    return true;
+  }
+
+  /**
+   * Create an ethernet packet based on the decrypted 802.11 data packet
+   * @param[in] pkt The 802.11 Data packet to convert
+   * @return The converted ethernet packet
+   */
+
+  static std::unique_ptr<Tins::Packet> make_eth_packet(Tins::Packet *pkt) {
+    auto data = pkt->pdu()->rfind_pdu<Tins::Dot11Data>();
+    auto eth2 = Tins::EthernetII(data.dst_addr(), data.src_addr());
+    if (data.find_pdu<Tins::SNAP>())
+      eth2 /= *data.find_pdu<Tins::SNAP>()->inner_pdu();
+    else
+      eth2 /= *data.inner_pdu();
+    return std::make_unique<Tins::Packet>(eth2, pkt->timestamp());
+  }
+
+private:
+  std::filesystem::path generate_path() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t currentTime = std::chrono::system_clock::to_time_t(now);
+    struct std::tm *timeInfo = std::localtime(&currentTime);
+    std::stringstream ss;
+    ss << basename << "-" << std::put_time(timeInfo, "%d-%m-%Y-%H:%M")
+       << ".pcap";
+
+    std::filesystem::path new_path = save_dir;
+    new_path.append(ss.str());
+    return new_path;
+  }
+
+  const std::filesystem::path save_dir;
+  const bool dump_raw = false;
+  std::string basename = "recording";
+};
+
+} // namespace yarilo
+
+#endif

--- a/backend/src/utils.h
+++ b/backend/src/utils.h
@@ -156,7 +156,7 @@ private:
     struct std::tm *timeInfo = std::localtime(&currentTime);
     std::stringstream ss;
     ss << basename << "-" << std::put_time(timeInfo, "%d-%m-%Y-%H:%M")
-       << ".pcap";
+       << ".pcapng";
 
     std::filesystem::path new_path = save_dir;
     new_path.append(ss.str());

--- a/frontend/src/lib/components/devel.svelte
+++ b/frontend/src/lib/components/devel.svelte
@@ -3,7 +3,7 @@
 	export let networkList: string[] = [];
 	export let focusedNetwork: string | null;
 
-	const mynet = 'Coherer';
+	const mynet = 'Schronisko Bielsko Biala';
 	const myclient = 'de:4e:d5:b2:3d:2e';
 	const myfilename = 'test.pcap';
 	const mynetname = 'wlp5s0f3u2';
@@ -11,14 +11,15 @@
 	let password: string = '';
 
 	import type { RpcError, FinishedUnaryCall } from '@protobuf-ts/runtime-rpc';
-	import type {
-		Empty,
-		NetworkList,
-		NetworkInfo,
-		NetworkName,
-		DecryptRequest,
-		RecordingsList,
-		Packet
+	import {
+		type Empty,
+		type NetworkList,
+		type NetworkInfo,
+		type NetworkName,
+		type DecryptRequest,
+		type RecordingsList,
+		type Packet,
+		DataLinkType
 	} from '$lib/proto/packets';
 	import { ensureConnected, client } from '$stores';
 	import { Button } from '$lib/components/ui/button';
@@ -87,10 +88,15 @@
 		});
 	};
 
-	const saveDecryptedTraffic = (ap: string) => () => {
+	const createRecording = (ap: string, decrypted: boolean) => () => {
 		ensureConnected().then(() => {
 			$client
-				.saveDecryptedTraffic({ snifferId: 0n, ssid: ap })
+				.recordingCreate({
+					snifferId: 0n,
+					singularAp: ap !== '',
+					ssid: ap,
+					dataLink: decrypted ? DataLinkType.ETH2 : DataLinkType.DOT11
+				})
 				.then(() => {
 					console.log('Saved traffic for', ap);
 				})
@@ -228,18 +234,36 @@
 </script>
 
 <Input type="password" bind:value={password} placeholder="Password!" />
-<Button on:click={providePassword(mynet)}>Confirm the password</Button>
-<Button on:click={getAccessPointDetails(mynet)}>Get the details of the network</Button>
-<Button on:click={deauth(mynet, myclient)}>Get the details of the network</Button>
-<Button on:click={ignoreNetwork(mynet)}>Ignore the network</Button>
-<Button on:click={getIgnoredNetworks}>Get the ignored networks</Button>
-<Button on:click={saveDecryptedTraffic(mynet)}>Save Decrypted Traffic</Button>
-<Button on:click={getDecryptedPackets(mynet)}>Get Decrypted Traffic</Button>
-<Button on:click={loadRecording('Coherer-10-03-2024-23:09.pcap')}>Load recording</Button>
-<Button on:click={getAvailableRecordings}>Get available recordings</Button>
-<Button on:click={fileSnifferCreate(myfilename)}>Create file Sniffer</Button>
-<Button on:click={netSnifferCreate(mynetname)}>Create network Sniffer</Button>
-<Button on:click={snifferDestroy}>Destroy Sniffer</Button>
-<Button on:click={snifferList}>List Active Sniffers</Button>
-<Button on:click={sniffFileList}>List Sniffer Files</Button>
-<Button on:click={sniffInterfaceList}>List Sniffer Interfaces</Button>
+<div>
+	<h1>General</h1>
+	<Button on:click={providePassword(mynet)}>Confirm the password</Button>
+	<Button on:click={getAccessPointDetails(mynet)}>Get the details of the network</Button>
+	<Button on:click={deauth(mynet, myclient)}>Get the details of the network</Button>
+	<Button on:click={ignoreNetwork(mynet)}>Ignore the network</Button>
+	<Button on:click={getIgnoredNetworks}>Get the ignored networks</Button>
+</div>
+
+<div>
+	<h1>Recordings</h1>
+	<Button on:click={createRecording(mynet, true)}>Save Decrypted Traffic For One network</Button>
+	<Button on:click={createRecording(mynet, false)}>Save All Traffic For One Network</Button>
+	<Button on:click={createRecording('', true)}>Save Decrypted Traffic</Button>
+	<Button on:click={createRecording('', false)}>Save All Traffic</Button>
+	<Button on:click={loadRecording('Coherer-10-03-2024-23:09.pcap')}>Load recording</Button>
+	<Button on:click={getAvailableRecordings}>Get available recordings</Button>
+</div>
+
+<div>
+	<h1>Sniffers</h1>
+	<Button on:click={fileSnifferCreate(myfilename)}>Create file Sniffer</Button>
+	<Button on:click={netSnifferCreate(mynetname)}>Create network Sniffer</Button>
+	<Button on:click={snifferDestroy}>Destroy Sniffer</Button>
+	<Button on:click={snifferList}>List Active Sniffers</Button>
+	<Button on:click={sniffFileList}>List Sniffer Files</Button>
+	<Button on:click={sniffInterfaceList}>List Sniffer Interfaces</Button>
+</div>
+
+<div>
+	<h1>Other</h1>
+	<Button on:click={getDecryptedPackets(mynet)}>Get Decrypted Traffic</Button>
+</div>

--- a/protos/packets.proto
+++ b/protos/packets.proto
@@ -118,8 +118,7 @@ message RecordingCreateRequest {
 }
 
 message RecordingCreateResponse {
-  string filename = 1;    // Generated filename in the saves directory
-  int64 packet_count = 2; // Total packet count across all APs
+  int64 packet_count = 1; // Total packet count across all APs
 }
 
 // User of a wireless netwokr (in tcp/udp packet streams)

--- a/protos/packets.proto
+++ b/protos/packets.proto
@@ -50,8 +50,9 @@ service Sniffer {
   // Get all the ignored networks.
   rpc GetIgnoredNetworks(SnifferID) returns (NetworkList) {}
 
-  // Save the decrypted stream from a network to a file.
-  rpc SaveDecryptedTraffic(NetworkName) returns (Empty) {}
+  // Save the stream from a network to a file.
+  rpc RecordingCreate(RecordingCreateRequest)
+      returns (RecordingCreateResponse) {}
 
   // Get all recordings on disk, those can also be loaded with `LoadRecording`.
   rpc GetAvailableRecordings(Empty) returns (RecordingsList) {}
@@ -98,6 +99,27 @@ message SniffInterfaceListResponse { repeated string net_iface_name = 1; }
 message NetworkName {
   int64 sniffer_id = 1;
   string ssid = 2;
+}
+
+// Netowrk data link layer types
+enum DataLinkType {
+  DOT11 = 0; // 802.11
+  ETH2 = 1;  // Ethernet 2
+}
+
+// Create a recording
+message RecordingCreateRequest {
+  int64 sniffer_id = 1;
+  bool singular_ap = 2;
+  string ssid = 3;            // If singular_ap is true
+  DataLinkType data_link = 4; // If data_link is set to 80211, we save raw
+                              // non-decrypted traffic, otherwise try to decrypt
+                              // traffic and then save it
+}
+
+message RecordingCreateResponse {
+  string filename = 1;    // Generated filename in the saves directory
+  int64 packet_count = 2; // Total packet count across all APs
 }
 
 // User of a wireless netwokr (in tcp/udp packet streams)


### PR DESCRIPTION
# Added

- Saving 802.11 or raw traffic from a single network, or an entire sniffer (which allows to trim down the recording for further later analysis) - solves #48 

# Changed

- `SaveRecording` has now been replaced with `RecordingCreate`, which provides a common interface for saving radiotap, 802.11 and ethernet converted decrypted packets. 