### PR TITLE
Allow exporting to hashcat

### DIFF
--- a/backend/src/decrypter.cpp
+++ b/backend/src/decrypter.cpp
@@ -104,6 +104,11 @@ std::vector<group_window> WPA2Decrypter::get_all_group_windows() const {
   return group_windows;
 }
 
+std::optional<std::string>
+WPA2Decrypter::extract_hc22000(const client_window &client) {
+  return "Jajco";
+}
+
 std::string WPA2Decrypter::readable_hex(const std::vector<uint8_t> &vec) {
   std::stringstream ss;
   for (uint8_t val : vec)

--- a/backend/src/decrypter.h
+++ b/backend/src/decrypter.h
@@ -142,8 +142,7 @@ public:
    * following for format specification:
    * https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2
    */
-  static std::optional<std::string>
-  extract_hc22000(const client_window &client);
+  std::optional<std::string> extract_hc22000(const client_window &client);
 
   /**
    * Makes a byte vector a pretty string like 0x03 0x02 0x01 to "030201"

--- a/backend/src/decrypter.h
+++ b/backend/src/decrypter.h
@@ -135,6 +135,17 @@ public:
   std::vector<group_window> get_all_group_windows() const;
 
   /**
+   * Extracts information needed for cracking the PSK of a WPA2 network for use
+   * with hashcat mode 22000
+   * @param[in] window The client window for which to extract data
+   * @return An optional containing the hc22000 formatted string, see the
+   * following for format specification:
+   * https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2
+   */
+  static std::optional<std::string>
+  extract_hc22000(const client_window &client);
+
+  /**
    * Makes a byte vector a pretty string like 0x03 0x02 0x01 to "030201"
    * @return string hex representation
    */

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -66,6 +66,10 @@ public:
                           const proto::APDeauthClientRequest *request,
                           proto::Empty *reply) override;
 
+  grpc::Status AccessPointGetHash(grpc::ServerContext *context,
+                                  const proto::APGetHashRequest *request,
+                                  proto::APGetHashResponse *reply) override;
+
   grpc::Status AccessPointIgnore(grpc::ServerContext *context,
                                  const proto::APIgnoreRequest *request,
                                  proto::Empty *reply) override;

--- a/frontend/src/lib/components/devel.svelte
+++ b/frontend/src/lib/components/devel.svelte
@@ -351,6 +351,18 @@
 		console.log('Deauth client state:', data.response);
 	};
 
+	const accessPointGetHash = (bssid: string, clientAddr: string) => async () => {
+		await ensureConnected();
+		let uuid = (await snifferListRet())[0].uuid;
+		let data = await $client.accessPointGetHash({
+			snifferUuid: uuid,
+			bssid: bssid,
+			clientAddr: clientAddr
+		});
+
+		console.log('Access point HC22000 hash:', data.response);
+	};
+
 	const accessPointIgnoreByAddress = (bssid: string) => async () => {
 		await ensureConnected();
 		let uuid = (await snifferListRet())[0].uuid;
@@ -559,6 +571,7 @@
 	<Button on:click={accessPointDeauthClient(mynet, myclient)}
 		>Deauthenticate a specific client</Button
 	>
+	<Button on:click={accessPointGetHash(mynet, myclient)}>Extract hashcat cracking info</Button>
 	<Button on:click={accessPointIgnoreByAddress(mynet)}>Ignore the network (by address)</Button>
 	<Button on:click={accessPointIgnoreByName(mynetName)}>Ignore the network (by name)</Button>
 	<Button on:click={accessPointListIgnored}>Get Ignored</Button>

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -19,6 +19,7 @@ service Sniffer {
       returns (stream Packet);
   rpc AccessPointDeauth(APDeauthRequest) returns (Empty);
   rpc AccessPointDeauthClient(APDeauthClientRequest) returns (Empty);
+  rpc AccessPointGetHash(APGetHashRequest) returns (APGetHashResponse);
   rpc AccessPointIgnore(APIgnoreRequest) returns (Empty);
   rpc AccessPointListIgnored(SnifferID) returns (APListResponse);
   rpc AccessPointCreateRecording(APCreateRecordingRequest)
@@ -356,6 +357,14 @@ message APDeauthClientRequest {
   string bssid = 2;
   string client_addr = 3;
 }
+
+message APGetHashRequest {
+  string sniffer_uuid = 1;
+  string bssid = 2;
+  string client_addr = 3;
+}
+
+message APGetHashResponse { string hc22000 = 1; }
 
 message APIgnoreRequest {
   string sniffer_uuid = 1;


### PR DESCRIPTION
## Added

- Users can now use the `AccessPointGetHash` endpoint to get `hc22000` hash data for cracking with [hashcat](https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2) - solves #21 
- The output includes extracted `PMKID` data - solves #60 