### PR TITLE
Ignoring a BSSID on startup

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -33,6 +33,10 @@ ABSL_FLAG(std::string, sniff_files_path, "/opt/yarlilo/sniff_files",
           "Directory which will be searched for sniff files (raw montior mode "
           "recordings)");
 ABSL_FLAG(std::string, log_level, "info", "Log level (debug, info, trace)");
+ABSL_FLAG(
+    std::string, ignore_bssid, "00:00:00:00:00:00",
+    "Ignore a bssid on startup, useful when controlling yarilo through a web "
+    "interface");
 
 std::optional<std::shared_ptr<spdlog::logger>> init_logger() {
   auto log = std::make_shared<spdlog::logger>(
@@ -156,8 +160,9 @@ int main(int argc, char *argv[]) {
   if (!sniff_files_path.has_value())
     return 1;
 
-  service = std::make_unique<yarilo::Service>(saves_path.value(),
-                                              sniff_files_path.value());
+  service = std::make_unique<yarilo::Service>(
+      saves_path.value(), sniff_files_path.value(),
+      absl::GetFlag(FLAGS_ignore_bssid));
   if (!init_first_sniffer(logger))
     return 1;
 

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -20,7 +20,8 @@ namespace yarilo {
 class Service : public proto::Sniffer::Service {
 public:
   Service(const std::filesystem::path &save_path,
-          const std::filesystem::path &sniff_path);
+          const std::filesystem::path &sniff_path,
+          const MACAddress &ignored_bssid = Sniffer::NoAddress);
 
   std::optional<uuid::UUIDv4>
   add_file_sniffer(const std::filesystem::path &file);
@@ -124,6 +125,7 @@ private:
   std::shared_ptr<spdlog::logger> logger;
   const std::filesystem::path save_path;
   const std::filesystem::path sniff_path;
+  const MACAddress ignored_bssid;
 };
 
 } // namespace yarilo

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -20,6 +20,8 @@ using DataLinkType = yarilo::Recording::DataLinkType;
 
 namespace yarilo {
 
+MACAddress Sniffer::NoAddress("00:00:00:00:00:00");
+
 Sniffer::Sniffer(std::unique_ptr<Tins::FileSniffer> sniffer,
                  const std::filesystem::path &filepath) {
   logger = spdlog::get(filepath.stem().string());

--- a/backend/src/sniffer.h
+++ b/backend/src/sniffer.h
@@ -24,7 +24,7 @@ enum ScanMode {
 class Sniffer {
 public:
   typedef std::pair<MACAddress, SSID> network_name;
-  MACAddress NoAddress = MACAddress("00:00:00:00:00:00");
+  static MACAddress NoAddress;
 
   /**
    * A constructor to create the Sniffer without network card support


### PR DESCRIPTION
## Added

- The flag `--ignore_bssid` allows the user to ignore a specific `BSSID`, for example `--ignore_bssid=68:d4:82:86:34:dd` - solves #59 