### PR TITLE
Optionally save packets on shutdown

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -172,8 +172,9 @@ int main(int argc, char *argv[]) {
   builder.RegisterService(service.get());
 
   std::signal(SIGINT, handle_signal);
-  std::signal(SIGQUIT, handle_signal);
+  std::signal(SIGHUP, handle_signal);
   std::signal(SIGTERM, handle_signal);
+  std::signal(SIGQUIT, handle_signal);
   std::thread t(shutdown_check);
   server = builder.BuildAndStart();
   t.join();

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -32,6 +32,8 @@ ABSL_FLAG(std::string, save_path, "/opt/yarlilo/saves",
 ABSL_FLAG(std::string, sniff_files_path, "/opt/yarlilo/sniff_files",
           "Directory which will be searched for sniff files (raw montior mode "
           "recordings)");
+ABSL_FLAG(bool, save_on_shutdown, false,
+          "Create a recording when the program terminates");
 ABSL_FLAG(std::string, log_level, "info", "Log level (debug, info, trace)");
 ABSL_FLAG(
     std::string, ignore_bssid, "00:00:00:00:00:00",
@@ -156,7 +158,7 @@ int main(int argc, char *argv[]) {
 
   service = std::make_unique<yarilo::Service>(
       saves_path.value(), sniff_files_path.value(),
-      absl::GetFlag(FLAGS_ignore_bssid));
+      absl::GetFlag(FLAGS_ignore_bssid), absl::GetFlag(FLAGS_save_on_shutdown));
   if (!init_first_sniffer(logger))
     return 1;
 

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -21,7 +21,8 @@ class Service : public proto::Sniffer::Service {
 public:
   Service(const std::filesystem::path &save_path,
           const std::filesystem::path &sniff_path,
-          const MACAddress &ignored_bssid = Sniffer::NoAddress);
+          const MACAddress &ignored_bssid = Sniffer::NoAddress,
+          bool save_on_shutdown = false);
 
   std::optional<uuid::UUIDv4>
   add_file_sniffer(const std::filesystem::path &file);
@@ -126,6 +127,7 @@ private:
   const std::filesystem::path save_path;
   const std::filesystem::path sniff_path;
   const MACAddress ignored_bssid;
+  const bool save_on_shutdown;
 };
 
 } // namespace yarilo


### PR DESCRIPTION
## Added

- The `--save_on_shutdown` flag enables the user to dump the packets onto the disk in a case where the program is killed