### PR TITLE
Check AP WiFi standards

### DIFF
--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -8,6 +8,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 #include <tins/ethernetII.h>
+#include <tins/exceptions.h>
 #include <tins/packet.h>
 #include <tins/tins.h>
 
@@ -475,8 +476,51 @@ std::vector<NetworkSecurity> AccessPoint::detect_security_modes(
 
 std::vector<wifi_standard_info> AccessPoint::detect_wifi_capabilities(
     const Tins::Dot11ManagementFrame &mgmt) const {
-  // NOTE: Used https://mcsindex.com to determine data about MCS index
   std::vector<wifi_standard_info> result;
+  bool has_supported_rates =
+      mgmt.search_option(Tins::Dot11::OptionTypes::SUPPORTED_RATES);
+  if (has_supported_rates) {
+    const std::vector<float> supported_rates = mgmt.supported_rates();
+    const std::set<float> supported_set(supported_rates.begin(),
+                                        supported_rates.end());
+    const std::set<float> dot11a_rates{6.0,  9.0,  12.0, 18.0,
+                                       24.0, 36.0, 48.0, 54.0};
+    bool has_dot11a_rates = std::all_of(
+        dot11a_rates.begin(), dot11a_rates.end(),
+        [&supported_set](float rate) { return supported_set.count(rate) > 0; });
+    if (has_dot11a_rates)
+      result.push_back(wifi_standard_info{
+          .std = WiFiStandard::Dot11A,
+          .modulation_supported = {Modulation::BPSK, Modulation::QPSK,
+                                   Modulation::QAM16, Modulation::QAM64},
+          .spatial_streams_supported = {1},
+          .channel_widths_supported = {ChannelWidth::CHAN20},
+      });
+
+    const std::set<float> dot11b_rates{1, 2, 5.5, 11};
+    bool has_dot11b_rates = std::all_of(
+        dot11b_rates.begin(), dot11b_rates.end(),
+        [&supported_set](float rate) { return supported_set.count(rate) > 0; });
+    result.push_back(wifi_standard_info{
+        .std = WiFiStandard::Dot11B,
+        .modulation_supported = {Modulation::BPSK, Modulation::QPSK,
+                                 Modulation::CCK},
+        .spatial_streams_supported = {1},
+        .channel_widths_supported = {ChannelWidth::CHAN20},
+    });
+
+    if (mgmt.search_option(
+            static_cast<Tins::Dot11::OptionTypes>(47))) // Extended Rate PHY
+      result.push_back(wifi_standard_info{
+          .std = WiFiStandard::Dot11G,
+          .modulation_supported = {Modulation::BPSK, Modulation::QPSK,
+                                   Modulation::QAM16, Modulation::QAM64},
+          .spatial_streams_supported = {1},
+          .channel_widths_supported = {ChannelWidth::CHAN20},
+      });
+  }
+
+  // NOTE: Used https://mcsindex.com to determine data about MCS index
   const Tins::Dot11::option *dot11n_cap =
       mgmt.search_option(Tins::Dot11::OptionTypes::HT_CAPABILITY);
   if (dot11n_cap) {

--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -13,6 +13,8 @@
 
 using NetworkSecurity = yarilo::AccessPoint::NetworkSecurity;
 using DecryptionState = yarilo::AccessPoint::DecryptionState;
+using Modulation = yarilo::AccessPoint::Modulation;
+using ChannelWidth = yarilo::AccessPoint::ChannelWidth;
 using wifi_standard_info = yarilo::AccessPoint::wifi_standard_info;
 using recording_info = yarilo::Recording::info;
 
@@ -49,7 +51,7 @@ MACAddress AccessPoint::get_bssid() const { return bssid; }
 
 int AccessPoint::get_wifi_channel() const { return wifi_channel; }
 
-std::vector<wifi_standard_info> AccessPoint::wifi_standards() const {
+std::vector<wifi_standard_info> AccessPoint::standards_supported() const {
   return wifi_stds_supported;
 }
 
@@ -285,13 +287,14 @@ bool AccessPoint::handle_management(Tins::Packet *pkt) {
   if (has_channel_info)
     wifi_channel = mgmt.ds_parameter_set();
 
-  if (!security_detected && (pkt->pdu()->find_pdu<Tins::Dot11Beacon>() ||
-                             pkt->pdu()->find_pdu<Tins::Dot11Beacon>())) {
+  if (!capabilities_detected && (pkt->pdu()->find_pdu<Tins::Dot11Beacon>() ||
+                                 pkt->pdu()->find_pdu<Tins::Dot11Beacon>())) {
     security_modes = detect_security_modes(mgmt);
     uses_ccmp = is_ccmp(mgmt);
     pmf_supported = check_pmf_capable(mgmt);
     pmf_required = check_pmf_required(mgmt);
-    wifi_stds_supported = detect_wifi_standards(mgmt);
+    wifi_stds_supported = detect_wifi_capabilities(mgmt);
+    capabilities_detected = true;
   }
 
   auto assoc = pkt->pdu()->find_pdu<Tins::Dot11AssocRequest>();
@@ -474,10 +477,109 @@ std::vector<NetworkSecurity> AccessPoint::detect_security_modes(
   return security_modes;
 }
 
-std::vector<wifi_standard_info> AccessPoint::detect_wifi_standards(
+std::vector<wifi_standard_info> AccessPoint::detect_wifi_capabilities(
     const Tins::Dot11ManagementFrame &mgmt) const {
-  // TODO
-  return {};
+  // NOTE: Used https://mcsindex.com to determine data about MCS index
+  std::vector<wifi_standard_info> result;
+  const Tins::Dot11::option *dot11n_cap =
+      mgmt.search_option(Tins::Dot11::OptionTypes::HT_CAPABILITY);
+  if (dot11n_cap) {
+    wifi_standard_info standard_info{
+        .std = WiFiStandard::Dot11N,
+        .channel_widths_supported{ChannelWidth::CHAN20, ChannelWidth::CHAN40}};
+    std::vector<uint8_t> mcs_bitset(dot11n_cap->data_ptr() + 3,
+                                    dot11n_cap->data_ptr() + 7);
+    for (int i = 0; i < 4; i++) {
+      if (mcs_bitset[i])
+        standard_info.spatial_streams_supported.insert(
+            i + 1); // 0-7 is one spatial stream, 8-15 is two, etc
+
+      if (mcs_bitset[i] & 0b00000001)
+        standard_info.modulation_supported.insert(Modulation::BPSK);
+      if (mcs_bitset[i] & 0b00000110)
+        standard_info.modulation_supported.insert(Modulation::QPSK);
+      if (mcs_bitset[i] & 0b00011000)
+        standard_info.modulation_supported.insert(Modulation::QAM16);
+      if (mcs_bitset[i] & 0b11100000)
+        standard_info.modulation_supported.insert(Modulation::QAM64);
+
+      for (int j = 0; j < 8; j++)
+        if (mcs_bitset[i] & (1 << j))
+          standard_info.mcs_supported_idx.insert(i * 8 + j);
+    }
+
+    bool supports_transmit_beamforming = dot11n_cap->data_ptr()[24] & 0x01;
+    standard_info.multi_beamformer_support = supports_transmit_beamforming;
+    standard_info.single_beamformer_support = supports_transmit_beamforming;
+    result.push_back(standard_info);
+  }
+
+  const Tins::Dot11::option *dot11ac_cap =
+      mgmt.search_option(Tins::Dot11::OptionTypes::VHT_CAP);
+  if (dot11ac_cap) {
+    wifi_standard_info standard_info{
+        .std = WiFiStandard::Dot11AC,
+        .channel_widths_supported{ChannelWidth::CHAN20, ChannelWidth::CHAN40,
+                                  ChannelWidth::CHAN80}};
+    std::vector<uint8_t> data(dot11ac_cap->data_ptr(),
+                              dot11ac_cap->data_ptr() +
+                                  dot11ac_cap->data_size());
+    if (data[0] & 0b00000100)
+      standard_info.channel_widths_supported.insert(ChannelWidth::CHAN160);
+    if (data[0] & 0b00001000)
+      standard_info.channel_widths_supported.insert(ChannelWidth::CHAN80_80);
+    standard_info.single_beamformee_support = data[1] & 0b00010000;
+    standard_info.single_beamformer_support = data[1] & 0b00001000;
+    standard_info.multi_beamformee_support = data[2] & 0b00010000;
+    standard_info.multi_beamformer_support = data[2] & 0b00001000;
+
+    // NOTE: I know this is incorrect accroding to the standards, but we will
+    // assume that spatial stream capabilities are identical when sending
+    // (wlan.vht.mcsset.txmcsmap) and receiving (wlan.vht.mcsset.rxmcsmap)
+    //
+    // Figure 9-562 IEEE 802.11-2016
+    // TODO: Make this more readable with bitsets
+    std::vector<uint8_t> mcs_bitset{data[4], data[5]};
+    int cnt = 0;
+    for (int i = 0; i < 2; i++)
+      for (int j = 0; j < 4; j++) {
+        cnt++;
+        uint8_t first_support_bit = (1 << (2 * j));
+        uint8_t second_support_bit = (1 << ((2 * j) + 1));
+        uint8_t n_streams_support =
+            (mcs_bitset[i] & (first_support_bit | second_support_bit)) >>
+            (2 * j);
+        if (n_streams_support == 3)
+          continue; // Not supported
+
+        standard_info.spatial_streams_supported.insert(cnt);
+        uint8_t max_mcs_for_stream = 0;
+        if (n_streams_support == 0)
+          max_mcs_for_stream = 7;
+        if (n_streams_support == 1)
+          max_mcs_for_stream = 8;
+        if (n_streams_support == 2)
+          max_mcs_for_stream = 9;
+        for (uint8_t n = 0; n < max_mcs_for_stream; n++)
+          standard_info.mcs_supported_idx.insert(n + 1);
+      }
+
+    if (standard_info.mcs_supported_idx.size()) {
+      standard_info.modulation_supported.insert(Modulation::BPSK);
+      standard_info.modulation_supported.insert(Modulation::QPSK);
+      standard_info.modulation_supported.insert(Modulation::QAM16);
+      standard_info.modulation_supported.insert(Modulation::QAM64);
+    }
+
+    if (standard_info.mcs_supported_idx.contains(8) ||
+        standard_info.mcs_supported_idx.contains(9))
+      standard_info.modulation_supported.insert(Modulation::QAM256);
+
+    result.push_back(standard_info);
+  }
+
+  // TODO: Handle HE (High Efficiency) 802.11ax frames
+  return result;
 }
 
 bool AccessPoint::check_pmf_capable(

--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -13,6 +13,7 @@
 
 using NetworkSecurity = yarilo::AccessPoint::NetworkSecurity;
 using DecryptionState = yarilo::AccessPoint::DecryptionState;
+using wifi_standard_info = yarilo::AccessPoint::wifi_standard_info;
 using recording_info = yarilo::Recording::info;
 
 namespace yarilo {
@@ -47,6 +48,10 @@ SSID AccessPoint::get_ssid() const { return ssid; }
 MACAddress AccessPoint::get_bssid() const { return bssid; }
 
 int AccessPoint::get_wifi_channel() const { return wifi_channel; }
+
+std::vector<wifi_standard_info> AccessPoint::wifi_standards() const {
+  return wifi_stds_supported;
+}
 
 std::shared_ptr<PacketChannel> AccessPoint::get_decrypted_channel() {
   auto new_chan = std::make_shared<PacketChannel>();
@@ -286,6 +291,7 @@ bool AccessPoint::handle_management(Tins::Packet *pkt) {
     uses_ccmp = is_ccmp(mgmt);
     pmf_supported = check_pmf_capable(mgmt);
     pmf_required = check_pmf_required(mgmt);
+    wifi_stds_supported = detect_wifi_standards(mgmt);
   }
 
   auto assoc = pkt->pdu()->find_pdu<Tins::Dot11AssocRequest>();
@@ -466,6 +472,12 @@ std::vector<NetworkSecurity> AccessPoint::detect_security_modes(
     security_modes.push_back(NetworkSecurity::WPA3_Enterprise);
 
   return security_modes;
+}
+
+std::vector<wifi_standard_info> AccessPoint::detect_wifi_standards(
+    const Tins::Dot11ManagementFrame &mgmt) const {
+  // TODO
+  return {};
 }
 
 bool AccessPoint::check_pmf_capable(

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -46,16 +46,19 @@ public:
    * many of them for a given access point
    */
   enum class WiFiStandard {
-    Dot11ABG, // Legacy standards like 802.11 a/b/g
-    Dot11N,   // Wi-Fi 4 or HT (High Throughput)
-    Dot11AC,  // Wi-Fi 5 or HVT (Very High Throughput)
-    Dot11AX,  // Wi-Fi 6 or HE (High Efficiency)
+    Dot11A,  // Legacy standards
+    Dot11B,  // Legacy standards
+    Dot11G,  // Legacy standards
+    Dot11N,  // Wi-Fi 4 or HT (High Throughput)
+    Dot11AC, // Wi-Fi 5 or HVT (Very High Throughput)
+    Dot11AX, // Wi-Fi 6 or HE (High Efficiency)
   };
 
   /*
    * @brief WiFi modulation type used
    */
   enum class Modulation {
+    CCK,   // Complementary code keying (802.11b)
     BPSK,  // Binary phase shift keying
     QPSK,  // Quadrature phase shift keying
     QAM16, // Quadrature amplitude modulation

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -41,6 +41,43 @@ public:
     ALREADY_DECRYPTED,
   };
 
+  /*
+   * @brief WiFi standard that is supported by an access point, there can be
+   * many of them for a given access point
+   */
+  enum class WiFiStandard {
+    Dot11ABG, // Legacy standards like 802.11 a/b/g
+    Dot11N,   // Wi-Fi 4 or HT (High Throughput)
+    Dot11AC,  // Wi-Fi 5 or HVT (Very High Throughput)
+    Dot11AX,  // Wi-Fi 6 or HE (High Efficiency)
+  };
+
+  /*
+   * @brief WiFi modulation type used
+   */
+  enum class Modulation {
+    BPSK,  // Binary phase shift keying
+    QPSK,  // Quadrature phase shift keying
+    QAM16, // Quadrature amplitude modulation
+    QAM64,
+    QAM256,
+    QAM1024,
+  };
+
+  /**
+   * @brief WiFi standard capabilities for the network
+   */
+  struct wifi_standard_info {
+    WiFiStandard std;
+    std::vector<uint8_t> mcs_supported_idx; // Indices of MCS
+    std::vector<Modulation> modulation_supported;
+    std::vector<uint8_t>
+        spacial_streams_supported; // Spatial stream configurations for MIMO,
+                                   // for example 3 means that the network
+                                   // supports 3 spatial streams, or 3x3
+    std::vector<uint8_t> channel_widths_supported;
+  };
+
   /**
    * @brief Client information
    */
@@ -108,6 +145,12 @@ public:
    * @return the wifi channel of the network
    */
   int get_wifi_channel() const;
+
+  /**
+   * Get standard capabilities
+   * @return Available standards and their possible settings
+   */
+  std::vector<wifi_standard_info> wifi_standards() const;
 
   /**
    * Get the converted data channel for this network
@@ -269,10 +312,17 @@ private:
 
   /**
    * Detect the security described in this management packet
-   * @param[in] mgtm A reference to a management packet
+   * @param[in] mgmt A reference to a management packet
    */
   std::vector<NetworkSecurity>
   detect_security_modes(const Tins::Dot11ManagementFrame &mgmt) const;
+
+  /**
+   * Detect network capabilities described in this management packet
+   * @param[in] mgmt A reference to a management packet
+   */
+  std::vector<wifi_standard_info>
+  detect_wifi_standards(const Tins::Dot11ManagementFrame &mgmt) const;
 
   /**
    * Check if the management packet supports Protected Management Frames (PMF).
@@ -302,6 +352,7 @@ private:
   std::vector<Tins::Packet *> captured_packets;
   WPA2Decrypter decrypter;
   std::vector<std::shared_ptr<PacketChannel>> converted_channels;
+  std::vector<wifi_standard_info> wifi_stds_supported;
 
   // Used for deauth, we need to "copy" the behaviour of the radiotap layer
   uint8_t radio_length = 0;

--- a/backend/src/access_point.h
+++ b/backend/src/access_point.h
@@ -64,18 +64,33 @@ public:
     QAM1024,
   };
 
+  /*
+   * @brief WiFi channel width used
+   */
+  enum class ChannelWidth {
+    CHAN20,
+    CHAN40,
+    CHAN80,
+    CHAN80_80,
+    CHAN160,
+  };
+
   /**
    * @brief WiFi standard capabilities for the network
    */
   struct wifi_standard_info {
     WiFiStandard std;
-    std::vector<uint8_t> mcs_supported_idx; // Indices of MCS
-    std::vector<Modulation> modulation_supported;
-    std::vector<uint8_t>
-        spacial_streams_supported; // Spatial stream configurations for MIMO,
+    bool single_beamformer_support;
+    bool single_beamformee_support;
+    bool multi_beamformer_support;
+    bool multi_beamformee_support;
+    std::set<uint8_t> mcs_supported_idx; // Indices of MCS
+    std::set<Modulation> modulation_supported;
+    std::set<uint8_t>
+        spatial_streams_supported; // Spatial stream configurations for MIMO,
                                    // for example 3 means that the network
                                    // supports 3 spatial streams, or 3x3
-    std::vector<uint8_t> channel_widths_supported;
+    std::set<ChannelWidth> channel_widths_supported;
   };
 
   /**
@@ -150,7 +165,7 @@ public:
    * Get standard capabilities
    * @return Available standards and their possible settings
    */
-  std::vector<wifi_standard_info> wifi_standards() const;
+  std::vector<wifi_standard_info> standards_supported() const;
 
   /**
    * Get the converted data channel for this network
@@ -322,7 +337,7 @@ private:
    * @param[in] mgmt A reference to a management packet
    */
   std::vector<wifi_standard_info>
-  detect_wifi_standards(const Tins::Dot11ManagementFrame &mgmt) const;
+  detect_wifi_capabilities(const Tins::Dot11ManagementFrame &mgmt) const;
 
   /**
    * Check if the management packet supports Protected Management Frames (PMF).
@@ -360,7 +375,7 @@ private:
   uint8_t radio_channel_type = 0;
   uint8_t radio_antenna = 0;
 
-  bool security_detected = false;
+  bool capabilities_detected = false;
   std::vector<NetworkSecurity> security_modes;
   bool pmf_supported = false; // 802.11w
   bool pmf_required = false;  // 802.11w

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -218,6 +218,20 @@ grpc::Status Service::AccessPointGet(grpc::ServerContext *context,
   for (const auto &sec : ap->security_supported())
     ap_info->add_security(static_cast<proto::NetworkSecurity>(sec));
 
+  for (const auto &standard : ap->wifi_standards()) {
+    auto new_standard = ap_info->add_supported_standards();
+    new_standard->set_std(static_cast<proto::WiFiStandard>(standard.std));
+    for (const auto &mcs : standard.mcs_supported_idx)
+      new_standard->add_mcs_supported_idx(mcs);
+    for (const auto &mod : standard.modulation_supported)
+      new_standard->add_modulation_supported(
+          static_cast<proto::Modulation>(mod));
+    for (const auto &spatial : standard.spacial_streams_supported)
+      new_standard->add_spacial_streams_supported(spatial);
+    for (const auto &width : standard.channel_widths_supported)
+      new_standard->add_channel_widths_supported(width);
+  }
+
   WPA2Decrypter &decrypter = ap->get_decrypter();
   for (const auto &client_addr : decrypter.get_clients()) {
     auto info = ap_info->add_clients();

--- a/backend/src/service.cpp
+++ b/backend/src/service.cpp
@@ -218,18 +218,27 @@ grpc::Status Service::AccessPointGet(grpc::ServerContext *context,
   for (const auto &sec : ap->security_supported())
     ap_info->add_security(static_cast<proto::NetworkSecurity>(sec));
 
-  for (const auto &standard : ap->wifi_standards()) {
+  for (const auto &standard : ap->standards_supported()) {
     auto new_standard = ap_info->add_supported_standards();
     new_standard->set_std(static_cast<proto::WiFiStandard>(standard.std));
+    new_standard->set_single_beamformer_support(
+        standard.single_beamformer_support);
+    new_standard->set_single_beamformee_support(
+        standard.single_beamformee_support);
+    new_standard->set_multi_beamformer_support(
+        standard.multi_beamformer_support);
+    new_standard->set_multi_beamformee_support(
+        standard.multi_beamformee_support);
     for (const auto &mcs : standard.mcs_supported_idx)
       new_standard->add_mcs_supported_idx(mcs);
     for (const auto &mod : standard.modulation_supported)
       new_standard->add_modulation_supported(
           static_cast<proto::Modulation>(mod));
-    for (const auto &spatial : standard.spacial_streams_supported)
-      new_standard->add_spacial_streams_supported(spatial);
+    for (const auto &spatial : standard.spatial_streams_supported)
+      new_standard->add_spatial_streams_supported(spatial);
     for (const auto &width : standard.channel_widths_supported)
-      new_standard->add_channel_widths_supported(width);
+      new_standard->add_channel_widths_supported(
+          static_cast<proto::ChannelWidth>(width));
   }
 
   WPA2Decrypter &decrypter = ap->get_decrypter();

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -86,19 +86,22 @@ enum NetworkSecurity {
 }
 
 enum WiFiStandard {
-  Dot11ABG = 0;
-  Dot11N = 1;
-  Dot11AC = 2;
-  Dot11AX = 3;
+  Dot11A = 0;
+  Dot11B = 1;
+  Dot11G = 2;
+  Dot11N = 3;
+  Dot11AC = 4;
+  Dot11AX = 5;
 }
 
 enum Modulation {
-  BPSK = 0;
-  QPSK = 1;
-  QAM16 = 2;
-  QAM64 = 3;
-  QAM256 = 4;
-  QAM1024 = 5;
+  CCK = 0;
+  BPSK = 1;
+  QPSK = 2;
+  QAM16 = 3;
+  QAM64 = 4;
+  QAM256 = 5;
+  QAM1024 = 6;
 }
 
 enum ChannelWidth {

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -85,6 +85,30 @@ enum NetworkSecurity {
   WPA3_Enterprise = 6;
 }
 
+enum WiFiStandard {
+  Dot11ABG = 0;
+  Dot11N = 1;
+  Dot11AC = 2;
+  Dot11AX = 3;
+}
+
+enum Modulation {
+  BPSK = 0;
+  QPSK = 1;
+  QAM16 = 2;
+  QAM64 = 3;
+  QAM256 = 4;
+  QAM1024 = 5;
+}
+
+message WiFiStandardInfo {
+  WiFiStandard std = 1;
+  repeated uint32 mcs_supported_idx = 2;
+  repeated Modulation modulation_supported = 3;
+  repeated uint32 spacial_streams_supported = 4;
+  repeated uint32 channel_widths_supported = 5;
+}
+
 message AccessPointInfo {
   string ssid = 1;
   string bssid = 2;
@@ -93,10 +117,11 @@ message AccessPointInfo {
   uint32 decrypted_packet_count = 5;
   bool pmf_capable = 6; // Protected management frames - 802.11w
   bool pmf_required = 7;
+  repeated WiFiStandardInfo supported_standards = 8;
   repeated NetworkSecurity security =
-      8; // A network can support multiple security standards at once
-  repeated ClientInfo clients = 9;
-  repeated GroupWindow group_windows = 10;
+      9; // A network can support multiple security standards at once
+  repeated ClientInfo clients = 10;
+  repeated GroupWindow group_windows = 11;
 }
 
 // End of AP.proto

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -101,12 +101,24 @@ enum Modulation {
   QAM1024 = 5;
 }
 
+enum ChannelWidth {
+  CHAN20 = 0;
+  CHAN40 = 1;
+  CHAN80 = 2;
+  CHAN80_80 = 3;
+  CHAN160 = 4;
+};
+
 message WiFiStandardInfo {
   WiFiStandard std = 1;
-  repeated uint32 mcs_supported_idx = 2;
-  repeated Modulation modulation_supported = 3;
-  repeated uint32 spacial_streams_supported = 4;
-  repeated uint32 channel_widths_supported = 5;
+  bool single_beamformer_support = 2;
+  bool single_beamformee_support = 3;
+  bool multi_beamformer_support = 4;
+  bool multi_beamformee_support = 5;
+  repeated uint32 mcs_supported_idx = 6;
+  repeated Modulation modulation_supported = 7;
+  repeated uint32 spatial_streams_supported = 8;
+  repeated ChannelWidth channel_widths_supported = 9;
 }
 
 message AccessPointInfo {


### PR DESCRIPTION
## Added

- Information about an access point now includes information about the supported 802.11 standards when it comes to transmission of packets, modulation and coding.