### PR TITLE
Battery support

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -33,6 +33,12 @@ if (YARILO_BUILD_DOCS)
   endif (DOXYGEN_FOUND)
 endif (YARILO_BUILD_DOCS)
 
+option(YARILO_BATTERY_SUPPORT "Enable displaying of battery levels" OFF)
+if(YARILO_BATTERY_SUPPORT)
+    add_compile_definitions(BATTERY_SUPPORT)
+    message(STATUS, "Battery support is enabled.")
+endif()
+
 # This branch assumes that gRPC and all its dependencies are already installed
 # on this system, so they can be located by find_package().
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM phusion/baseimage:jammy-1.0.4
 
+# We take the battery option as an argument
+ARG BATTERY_SUPPORT=OFF
+
 # Copy the binaries and libs from the builder
 COPY --from=typicalam/yarilo-build:latest /app/deps /app/deps
 
@@ -15,7 +18,7 @@ RUN apt-get update \
 # Build yarilo
 RUN git clone https://github.com/TypicalAM/Yarilo /app/src \
 	&& /app/deps/bin/protoc -I /app/src/protos --doc_opt=markdown,proto.md --doc_out=/app/src/backend/docs --plugin=protoc-gen-doc=/app/deps/bin/protoc-gen-doc /app/src/protos/service.proto \
-	&& cmake -DCMAKE_PREFIX_PATH=/app/deps -DYARILO_BUILD_DOCS=ON -B /app/src/backend/build -G Ninja /app/src/backend \
+	&& cmake -DCMAKE_PREFIX_PATH=/app/deps -DYARILO_BUILD_DOCS=ON -DYARILO_BATTERY_SUPPORT=$BATTERY_SUPPORT -B /app/src/backend/build -G Ninja /app/src/backend \
 	&& ninja -C /app/src/backend/build && mv /app/src/backend/build/yarilo /yarilo
 
 # Set up the run script

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -19,7 +19,7 @@ set -e
 export PATH="/app/deps/bin:$(go env GOPATH)/bin:$PATH"
 envoy -c /app/src/backend/envoy.yaml --log-path /app/envoy.log >/dev/null 2>&1 &
 protoc -I /app/src/protos --cpp_out=/app/src/backend/src/proto --doc_opt=markdown,proto.md --doc_out=/app/src/backend/docs --grpc_out=/app/src/backend/src/proto --plugin=protoc-gen-grpc=$(which grpc_cpp_plugin) /app/src/protos/service.proto
-cmake -DCMAKE_PREFIX_PATH=/app/deps -G Ninja -B /app/build /app/src/backend
+cmake -DCMAKE_PREFIX_PATH=/app/deps -DYARILO_BATTERY_SUPPORT=ON -G Ninja -B /app/build /app/src/backend
 ninja -C /app/build
 /app/build/yarilo \$*
 EOF

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -39,7 +39,7 @@ ABSL_FLAG(
     std::string, ignore_bssid, "00:00:00:00:00:00",
     "Ignore a bssid on startup, useful when controlling yarilo through a web "
     "interface");
-ABSL_FLAG(std::string, battery_path, "/tmp/battery_level",
+ABSL_FLAG(std::string, battery_file, "/tmp/battery_level",
           "File path to the file with the yarilo battery percentage (only with "
           "battery support enabled)");
 
@@ -105,7 +105,7 @@ init_battery_file(std::shared_ptr<spdlog::logger> log) {
 #ifndef BATTERY_SUPPORT
   return "/dev/null";
 #else
-  std::filesystem::path battery_file = absl::GetFlag(FLAGS_battery_path);
+  std::filesystem::path battery_file = absl::GetFlag(FLAGS_battery_file);
   if (!std::filesystem::exists(battery_file)) {
     log->critical("Battery file {} doesn't exist!", battery_file.string());
     return std::nullopt;

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -39,6 +39,9 @@ ABSL_FLAG(
     std::string, ignore_bssid, "00:00:00:00:00:00",
     "Ignore a bssid on startup, useful when controlling yarilo through a web "
     "interface");
+ABSL_FLAG(std::string, battery_path, "/tmp/battery_level",
+          "File path to the file with the yarilo battery percentage (only with "
+          "battery support enabled)");
 
 bool set_log_level() {
   std::string log_level = absl::GetFlag(FLAGS_log_level);
@@ -95,6 +98,21 @@ init_sniff_files(std::shared_ptr<spdlog::logger> log) {
   }
 
   return sniff_files;
+}
+
+std::optional<std::filesystem::path>
+init_battery_file(std::shared_ptr<spdlog::logger> log) {
+#ifndef BATTERY_SUPPORT
+  return "/dev/null";
+#else
+  std::filesystem::path battery_file = absl::GetFlag(FLAGS_battery_path);
+  if (!std::filesystem::exists(battery_file)) {
+    log->critical("Battery file {} doesn't exist!", battery_file.string());
+    return std::nullopt;
+  }
+
+  return battery_file;
+#endif // BATTERY_SUPPORT
 }
 
 bool init_first_sniffer(std::shared_ptr<spdlog::logger> log) {
@@ -156,8 +174,12 @@ int main(int argc, char *argv[]) {
   if (!sniff_files_path.has_value())
     return 1;
 
+  std::optional<std::filesystem::path> battery_file = init_battery_file(logger);
+  if (!battery_file.has_value())
+    return 1;
+
   service = std::make_unique<yarilo::Service>(
-      saves_path.value(), sniff_files_path.value(),
+      saves_path.value(), sniff_files_path.value(), battery_file.value(),
       absl::GetFlag(FLAGS_ignore_bssid), absl::GetFlag(FLAGS_save_on_shutdown));
   if (!init_first_sniffer(logger))
     return 1;

--- a/backend/src/service.h
+++ b/backend/src/service.h
@@ -21,6 +21,7 @@ class Service : public proto::Sniffer::Service {
 public:
   Service(const std::filesystem::path &save_path,
           const std::filesystem::path &sniff_path,
+          const std::filesystem::path &battery_file,
           const MACAddress &ignored_bssid = Sniffer::NoAddress,
           bool save_on_shutdown = false);
 
@@ -119,6 +120,10 @@ public:
   LogGetStream(grpc::ServerContext *context, const proto::Empty *request,
                grpc::ServerWriter<proto::LogEntry> *writer) override;
 
+  grpc::Status BatteryGetLevel(grpc::ServerContext *context,
+                               const proto::Empty *request,
+                               proto::BatteryGetLevelResponse *reply) override;
+
 private:
   std::unordered_map<uuid::UUIDv4, std::unique_ptr<Sniffer>> sniffers;
   std::unordered_map<uuid::UUIDv4, std::unique_ptr<Sniffer>>
@@ -126,6 +131,7 @@ private:
   std::shared_ptr<spdlog::logger> logger;
   const std::filesystem::path save_path;
   const std::filesystem::path sniff_path;
+  const std::filesystem::path battery_file;
   const MACAddress ignored_bssid;
   const bool save_on_shutdown;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./protos:/app/src/protos
       - ./dev-save-data:/app/saves
       - ./dev-build-data:/app/build
+      - /tmp/battery_level:/tmp/battery_level
 
 volumes:
   build_data:

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "314e12ba369ccdb9b352a4db26ff419f7c49fa84",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
 
         # Runtime package
         packages.Yarilo = pkgs.callPackage ./backend { };
+        packages.YariloBattery = (pkgs.callPackage ./backend { }).overrideAttrs (oldAttrs: rec {
+          cmakeFlags = oldAttrs.cmakeFlags or [ ] ++ [ "-DYARILO_BATTERY_SUPPORT=ON" ];
+        });
         packages.YariloFrontend = pkgs.callPackage ./frontend { };
 
         # Default package

--- a/frontend/src/lib/components/devel.svelte
+++ b/frontend/src/lib/components/devel.svelte
@@ -516,6 +516,12 @@
 		});
 	};
 
+	const batteryGetLevel = async () => {
+		await ensureConnected();
+		let response = await $client.batteryGetLevel({}).response;
+		console.log('Battery get level:', response);
+	};
+
 	// End of miscellaneous
 
 	const printPacket = (pkt: Packet) => {
@@ -603,6 +609,7 @@
 	<h1>Misc</h1>
 	<Button on:click={networkInterfaceList}>Get network interfaces</Button>
 	<Button on:click={logGetStream}>Get Log Stream</Button>
+	<Button on:click={batteryGetLevel}>Get Battery Percentage</Button>
 </div>
 
 <style>

--- a/frontend/src/lib/proto/service.client.ts
+++ b/frontend/src/lib/proto/service.client.ts
@@ -4,6 +4,7 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { Sniffer } from "./service";
+import type { BatteryGetLevelResponse } from "./service";
 import type { LogEntry } from "./service";
 import type { NetworkInterfaceListResponse } from "./service";
 import type { RecordingLoadDecryptedRequest } from "./service";
@@ -127,6 +128,10 @@ export interface ISnifferClient {
      * @generated from protobuf rpc: LogGetStream(proto.Empty) returns (stream proto.LogEntry);
      */
     logGetStream(input: Empty, options?: RpcOptions): ServerStreamingCall<Empty, LogEntry>;
+    /**
+     * @generated from protobuf rpc: BatteryGetLevel(proto.Empty) returns (proto.BatteryGetLevelResponse);
+     */
+    batteryGetLevel(input: Empty, options?: RpcOptions): UnaryCall<Empty, BatteryGetLevelResponse>;
 }
 /**
  * The Sniffer service is responsible capturing data from a file or a network
@@ -286,5 +291,12 @@ export class SnifferClient implements ISnifferClient, ServiceInfo {
     logGetStream(input: Empty, options?: RpcOptions): ServerStreamingCall<Empty, LogEntry> {
         const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<Empty, LogEntry>("serverStreaming", this._transport, method, opt, input);
+    }
+    /**
+     * @generated from protobuf rpc: BatteryGetLevel(proto.Empty) returns (proto.BatteryGetLevelResponse);
+     */
+    batteryGetLevel(input: Empty, options?: RpcOptions): UnaryCall<Empty, BatteryGetLevelResponse> {
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        return stackIntercept<Empty, BatteryGetLevelResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/frontend/src/lib/proto/service.ts
+++ b/frontend/src/lib/proto/service.ts
@@ -1231,6 +1231,15 @@ export enum LogEntry_LogLevel {
     CRITICAL = 5
 }
 /**
+ * @generated from protobuf message proto.BatteryGetLevelResponse
+ */
+export interface BatteryGetLevelResponse {
+    /**
+     * @generated from protobuf field: float percentage = 1;
+     */
+    percentage: number;
+}
+/**
  * @generated from protobuf enum proto.NetworkSecurity
  */
 export enum NetworkSecurity {
@@ -4973,6 +4982,53 @@ class LogEntry$Type extends MessageType<LogEntry> {
  * @generated MessageType for protobuf message proto.LogEntry
  */
 export const LogEntry = new LogEntry$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class BatteryGetLevelResponse$Type extends MessageType<BatteryGetLevelResponse> {
+    constructor() {
+        super("proto.BatteryGetLevelResponse", [
+            { no: 1, name: "percentage", kind: "scalar", T: 2 /*ScalarType.FLOAT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<BatteryGetLevelResponse>): BatteryGetLevelResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.percentage = 0;
+        if (value !== undefined)
+            reflectionMergePartial<BatteryGetLevelResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: BatteryGetLevelResponse): BatteryGetLevelResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* float percentage */ 1:
+                    message.percentage = reader.float();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: BatteryGetLevelResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* float percentage = 1; */
+        if (message.percentage !== 0)
+            writer.tag(1, WireType.Bit32).float(message.percentage);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message proto.BatteryGetLevelResponse
+ */
+export const BatteryGetLevelResponse = new BatteryGetLevelResponse$Type();
 /**
  * @generated ServiceType for protobuf service proto.Sniffer
  */
@@ -4997,5 +5053,6 @@ export const Sniffer = new ServiceType("proto.Sniffer", [
     { name: "RecordingList", options: {}, I: RecordingListRequest, O: RecordingListResponse },
     { name: "RecordingLoadDecrypted", serverStreaming: true, options: {}, I: RecordingLoadDecryptedRequest, O: Packet },
     { name: "NetworkInterfaceList", options: {}, I: Empty, O: NetworkInterfaceListResponse },
-    { name: "LogGetStream", serverStreaming: true, options: {}, I: Empty, O: LogEntry }
+    { name: "LogGetStream", serverStreaming: true, options: {}, I: Empty, O: LogEntry },
+    { name: "BatteryGetLevel", options: {}, I: Empty, O: BatteryGetLevelResponse }
 ]);

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -36,6 +36,7 @@ service Sniffer {
 
   rpc NetworkInterfaceList(Empty) returns (NetworkInterfaceListResponse);
   rpc LogGetStream(Empty) returns (stream LogEntry);
+  rpc BatteryGetLevel(Empty) returns (BatteryGetLevelResponse);
 }
 
 // AP.proto
@@ -479,3 +480,5 @@ message LogEntry {
   string scope = 3;
   string payload = 4;
 }
+
+message BatteryGetLevelResponse { float percentage = 1; }


### PR DESCRIPTION
Added:
- New endpoint for viewing battery levels via a `--battery_file`, which is a file with the percentage of the battery, for example `100.00` or `69.420`. It is for use in our personal self-powered systems.