### PR TITLE
Non-linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ You can use `typicalam/yarilo:latest` as the base docker image. This project has
 docker compose up -d
 ```
 
+or if you on a host that does not support host networking (MacOS, Windows) you can run:
+
+```sh
+docker network create yarilo-net
+docker run --rm -d --net yarilo-net -p 8080:8080 -e "YARILO_ADDRESS=yarilo" typicalam/yarilo-envoy:latest
+docker run --rm -it --name yarilo --net yarilo-net -v /tmp/saves:/app/saves -v ./pcap:/tmp/pcap -p 9090:9090 typicalam/yarilo:latest --oid_file_path=/app/data/oid.txt --save_path=/app/saves --db_file_path=/app/saves/yarilo_database.db --sniff_file=/tmp/pcap/wireshark_sample.pcap
+```
+
 ## Development
 
 What about running this thing locally?

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,7 +1,10 @@
 FROM envoyproxy/envoy:v1.31-latest
 
-COPY envoy/envoy.yaml /app/envoy.yaml
+COPY envoy/envoy.yaml /app/envoy-original.yaml
+COPY envoy/entrypoint.sh /app/entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/envoy"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["-c", "/app/envoy.yaml", "--log-path", "/app/envoy.log"]

--- a/envoy/entrypoint.sh
+++ b/envoy/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ -z "$YARILO_ADDRESS" ]; then
+	echo "No YARILO_ADDRESS specified, defaulting to 0.0.0.0"
+	export YARILO_ADDRESS="0.0.0.0"
+fi
+
+sed "s/address: 0\.0\.0\.0$/address: $YARILO_ADDRESS/" /app/envoy-original.yaml >/app/envoy.yaml
+/usr/local/bin/envoy $*


### PR DESCRIPTION
Changed:

- `Envoy` now takes in an argument for the target backend, allowing it to function on non-mac systems in the case of file-based sniffers (solves #74)