### PR TITLE
Generate docs for proto files in docker 

### DIFF
--- a/backend/Dockerfile.docs
+++ b/backend/Dockerfile.docs
@@ -8,6 +8,16 @@ FROM base AS builder
 # Capture deps into /nix/store
 COPY . /src
 WORKDIR /src
+
+# Generate documentation for proto definitions
+RUN GOPATH=/tmp/go nix \
+	--extra-experimental-features "nix-command flakes" \
+	--option filter-syscalls false \
+	develop \
+	--command sh -c "go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest && protoc -Iprotos --doc_opt=markdown,proto.md --doc_out=backend/docs --plugin=protoc-gen-doc=/tmp/go/bin/protoc-gen-doc protos/service.proto" \
+	&& rm -rf /tmp/go
+
+# Build the project
 RUN nix --extra-experimental-features "nix-command flakes" \
 	  --option filter-syscalls false \
 	  build .

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         # Development shell
         devShell = mkShell {
           name = "yarilo";
-          nativeBuildInputs = [ doxygen clang-tools gdb cmake ninja spdlog grpc libtins protobuf openssl libpcap aircrack-ng iw libnl nodejs protobuf sqlite ];
+          nativeBuildInputs = [ doxygen clang-tools gdb cmake ninja spdlog grpc libtins protobuf openssl libpcap aircrack-ng iw libnl nodejs protobuf sqlite go ];
         };
 
         # Runtime package


### PR DESCRIPTION
Changed:

- `Dockerfile.docs` now generates a `backend/docs/proto.md` before building to include this page in the build