### PR TITLE
Shorter logger and recording names

### DIFF
--- a/backend/src/access_point.cpp
+++ b/backend/src/access_point.cpp
@@ -3,7 +3,6 @@
 #include "log_sink.h"
 #include "recording.h"
 #include <algorithm>
-#include <fstream>
 #include <optional>
 #include <semaphore.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -193,10 +192,7 @@ AccessPoint::save_traffic(const std::filesystem::path &dir_path,
                           const std::string &name) {
   logger->debug("Creating a raw recording with {} packets",
                 captured_packets.size());
-
-  Recording rec(dir_path, true, db);
-  rec.set_name(name);
-  return rec.dump(&captured_packets);
+  return Recording(dir_path, true, db, name).dump(&captured_packets);
 }
 
 std::optional<recording_info>
@@ -208,11 +204,7 @@ AccessPoint::save_decrypted_traffic(const std::filesystem::path &dir_path,
 
   logger->debug("Creating a decrypted recording with {} packets",
                 channel->len());
-
-  Recording rec(dir_path, false, db);
-  rec.set_name(name);
-
-  return rec.dump(std::move(channel));
+  return Recording(dir_path, false, db, name).dump(std::move(channel));
 }
 
 bool AccessPoint::handle_data(Tins::Packet *pkt) {

--- a/backend/src/log_sink.cpp
+++ b/backend/src/log_sink.cpp
@@ -12,11 +12,14 @@ spdlog::level::level_enum global_log_level = spdlog::level::info;
 
 std::shared_ptr<spdlog::logger> get_logger(const std::string &name) {
   auto color_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+  std::string sink_name = name;
+  if (sink_name.size() > 25)
+    sink_name = sink_name.substr(0, 25);
 
-  std::shared_ptr<spdlog::logger> logger = spdlog::get(name);
+  std::shared_ptr<spdlog::logger> logger = spdlog::get(sink_name);
   if (!logger) {
     logger = std::make_shared<spdlog::logger>(
-        name,
+        sink_name,
         spdlog::sinks_init_list{global_proto_sink, std::move(color_sink)});
     logger->set_level(global_log_level);
   }

--- a/backend/src/recording.h
+++ b/backend/src/recording.h
@@ -45,15 +45,11 @@ public:
    * Constructs a new Recording object.
    * @param[in] save_dir The directory where the recordings will be saved.
    * @param[in] dump_raw A boolean indicating whether to dump raw packet data.
+   * @param[in] db Database reference.
+   * @param[in] display_name Display name for the recording.
    */
-  Recording(const std::filesystem::path &save_dir, bool dump_raw, Database &db);
-
-  /**
-   * Sets the base name for the recording.
-   * @param[in] basename The base name to be used for the recording file (for
-   * example the AP name)
-   */
-  void set_name(const std::string &basename) { this->basename = basename; }
+  Recording(const std::filesystem::path &save_dir, bool dump_raw, Database &db,
+            const std::string &display_name);
 
   /**
    * Dumps the packets from the given PacketChannel to a recording file.
@@ -80,16 +76,16 @@ public:
 
 private:
   /*
-   * Generates a filename for the recording file.
-   * @return The generated filename as a path object.
+   * Generates a path for the recording file.
+   * @return The generated recording path as a path object.
    */
-  std::filesystem::path generate_filename() const;
+  std::filesystem::path generate_filepath() const;
 
   std::shared_ptr<spdlog::logger> logger;
   const std::filesystem::path save_dir;
-  const bool dump_raw = false;
-  std::string basename = "recording";
-  uuid::UUIDv4 uuid;
+  const bool dump_raw;
+  const std::string basename;
+  const uuid::UUIDv4 uuid;
   Database &db;
 };
 

--- a/backend/src/sniffer.cpp
+++ b/backend/src/sniffer.cpp
@@ -216,8 +216,7 @@ std::optional<recording_info>
 Sniffer::save_traffic(const std::filesystem::path &dir_path,
                       const std::string &name) {
   logger->debug("Creating a raw recording with {} packets", packets.size());
-  Recording rec(dir_path, true, db);
-  rec.set_name(name);
+  Recording rec(dir_path, true, db, name);
 
   auto channel = std::make_unique<PacketChannel>();
   for (const auto &pkt : packets)
@@ -278,8 +277,7 @@ Sniffer::save_traffic(const std::filesystem::path &dir_path,
 std::optional<recording_info>
 Sniffer::save_decrypted_traffic(const std::filesystem::path &dir_path,
                                 const std::string &name) {
-  Recording rec(dir_path, false, db);
-  rec.set_name(name);
+  Recording rec(dir_path, false, db, name);
 
   auto channel = std::make_unique<PacketChannel>();
   for (auto &pkt : packets) {


### PR DESCRIPTION
Changed:

- Recordings now have a shorter file name by default and add numbers to the end if the file already exists
- Loggers now have a cap of 25 characters per logger name (solves #81)